### PR TITLE
chore: migrate to ts-builds 3.0.0 + pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,0 @@
-# Hoist CLI tool binaries from peer dependencies
-public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
-public-hoist-pattern[]=*vitest*
-public-hoist-pattern[]=typescript
-public-hoist-pattern[]=*rimraf*
-public-hoist-pattern[]=*cross-env*

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.13.1",
-    "ts-builds": "^2.8.2",
+    "ts-builds": "^3.0.0",
     "tsdown": "^0.22.2",
     "tsx": "^4.22.4"
   },
@@ -71,5 +71,5 @@
     "schemas"
   ],
   "prettier": "ts-builds/prettier",
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^24.13.1
         version: 24.13.1
       ts-builds:
-        specifier: ^2.8.2
-        version: 2.8.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.1(@types/node@24.13.1)(tsx@4.22.4))
+        specifier: ^3.0.0
+        version: 3.0.0(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.1(@types/node@24.13.1)(tsx@4.22.4))
       tsdown:
         specifier: ^0.22.2
         version: 0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13))
@@ -2340,9 +2340,10 @@ packages:
     peerDependencies:
       typescript: ">=4.8.4"
 
-  ts-builds@2.8.2:
+  ts-builds@3.0.0:
     resolution:
-      { integrity: sha512-gAnX6NN18S0zbd9a98oVN+7fOs0hwjVDy9QJokkWkwa30DJm7eovJF3gHABYyaOIIUa/34agMlHPgSm/D9/Dkg== }
+      { integrity: sha512-w5l0UZTfpmp6ZH9nfg0x+JwyBJOYXH2TjYTajwKI0pAfhdpP611RaL1JJvjjyvvL3aHl75/8fa0jMhkvmJiyFg== }
+    engines: { node: ">=22" }
     hasBin: true
     peerDependencies:
       tsdown: ^0.x
@@ -4280,7 +4281,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-builds@2.8.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.1(@types/node@24.13.1)(tsx@4.22.4)):
+  ts-builds@3.0.0(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39(synckit@0.11.13)))(vite@7.3.1(@types/node@24.13.1)(tsx@4.22.4)):
     dependencies:
       "@eslint/js": 10.0.1(eslint@10.4.1)
       "@types/node": 24.10.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,17 @@
+allowBuilds:
+  esbuild: false # binary ships via @esbuild/<platform> optional deps; postinstall not needed
+
+minimumReleaseAgeExclude:
+  - "@types/node@24.13.1" # auto-added (no aged alternative for ^24.13.1)
+  - "ts-builds" # first-party, all versions always allowed
+  - "functype" # first-party functype libs, all versions always allowed
+  - "functype-log"
+  - "functype-os"
+
+publicHoistPattern:
+  - "*eslint*"
+  - "*prettier*"
+  - "*vitest*"
+  - "typescript"
+  - "*rimraf*"
+  - "*cross-env*"


### PR DESCRIPTION
ts-builds 3.0.0 *is* the pnpm 11 migration — its bundled toolchain is identical to 2.8.2. pnpm 11 makes `.npmrc` auth/registry-only and stops reading the `package.json` `pnpm` field; non-auth settings move to `pnpm-workspace.yaml`.

## Changes
- `ts-builds` `^2.8.2` → `^3.0.0`
- `packageManager` `pnpm@10.33.0` → `pnpm@11.5.2` (corepack)
- `.npmrc` hoist patterns → `pnpm-workspace.yaml` `publicHoistPattern` (via `ts-builds doctor --fix`)
- `allowBuilds.esbuild: false` — pnpm 11 replaces `onlyBuiltDependencies`; esbuild's binary ships via `@esbuild/<platform>` optional deps, so its postinstall isn't needed (verified by green build)
- `minimumReleaseAgeExclude` — pnpm 11 enables `minimumReleaseAge: 1440` by default; exclude first-party libs (`ts-builds`, `functype*`) + `@types/node@24.13.1` (no aged alternative for `^24.13.1`)

## Validation
`pnpm validate` green under pnpm 11.5.2: format → lint → typecheck → **470 tests pass** → schema → build. Lockfile stays `lockfileVersion: 9.0`.

## CI note
Both workflows use `pnpm/action-setup@v4` + `.nvmrc=24`, so they auto-pick pnpm 11.5.2. The `@types/node@24.13.1` exclude becomes unnecessary once it ages past the 24h window but is harmless to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)