### PR TITLE
fix(docs): make site build under pnpm 11 + fix Starlight 0.39 sidebar

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -72,7 +72,7 @@ export default defineConfig({
         },
         {
           label: "Examples",
-          autogenerate: { directory: "examples" },
+          items: [{ autogenerate: { directory: "examples" } }],
         },
       ],
     }),

--- a/site/package.json
+++ b/site/package.json
@@ -19,11 +19,5 @@
     "react-dom": "^19.2.7",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
   }
 }

--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+
+minimumReleaseAgeExclude:
+  - "@types/mdx@2.0.14"           # auto-added (no aged alternative)
+  - "@types/node@24.13.1"         # auto-added (no aged alternative for ^24.13.1)
+  - "@types/react@19.2.17"        # auto-added (no aged alternative)
+  - "caniuse-lite@1.0.30001797"   # auto-added (browserslist data pkg; churns daily)


### PR DESCRIPTION
Fixes the failing Cloudflare Pages docs deploy.

## Root cause (layered)
CF Build system v3 installs deps at the **repo root** (435-entry root lockfile) but runs the build command inside the **`site` root directory**, where deps were never installed → `astro: not found` / `node_modules missing`. Once install is fixed, two more latent failures surface — `site/` was never migrated to pnpm 11, and Starlight 0.39 broke the sidebar config.

## Changes (this PR)
1. **pnpm 11 readiness for `site/`** — `site/package.json`'s deprecated `pnpm.onlyBuiltDependencies` (ignored by pnpm 11) → `site/pnpm-workspace.yaml` `allowBuilds: {esbuild: true, sharp: true}` (faithful 1:1; `sharp` native build verified)
2. **`minimumReleaseAgeExclude`** — pnpm 11 enables `minimumReleaseAge: 1440` by default; pinned 4 too-fresh transitive deps (`@types/mdx`, `@types/node@24.13.1`, `@types/react`, `caniuse-lite`)
3. **Starlight 0.39 sidebar** — `autogenerate`+`label` groups were removed; wrapped the Examples group in `items: [{ autogenerate: … }]`

## Verified
Clean `pnpm --dir site install` + `pnpm run build` → **39 pages built**, search index, sitemap. `site/pnpm-lock.yaml` unchanged.

## ⚠️ Also requires a Cloudflare dashboard change (not in this PR)
Build command `pnpm run build` → **`pnpm install && pnpm run build`**. The command runs in the `site` root directory, so this installs the site lockfile there before `astro build`. Root directory (`site`) and output (`dist`) are already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)