### PR TITLE
feat: namespace prefix for injected env var names

### DIFF
--- a/.claude/skills/envpkt/SKILL.md
+++ b/.claude/skills/envpkt/SKILL.md
@@ -198,6 +198,37 @@ rows with inherited status and an `alias_of` marker — lifecycle tracking lives
 on the target, so an alias is healthy iff its target is. Cross-type aliasing
 (secret → env) is rejected at config load time.
 
+### Namespace (`[namespace]`)
+
+Prefix the **injected** env var name for every `[secret.*]`/`[env.*]` entry
+without changing the TOML keys you author or the names shown in audit/inspect.
+The TOML key stays logical; the prefix is applied only at the `process.env`
+boundary (`boot()`, `exec`, `env export`).
+
+```toml
+[namespace]
+prefix    = "CIV"
+separator = "__"   # optional, default; MUST be shell-safe ([A-Za-z0-9_])
+
+[secret.API_KEY]   # injected as CIV__API_KEY
+service = "example"
+
+[env.LOG_LEVEL]    # injected as CIV__LOG_LEVEL
+value = "info"
+
+[secret.SHARED]    # per-entry override; "" opts out → injected as plain SHARED
+service = "svc"
+namespace = ""
+```
+
+- **Use `_` or `__`** as the separator. `.` and `:` are not valid in shell
+  variable names — `$CIV.API_KEY` fails to parse, `$CIV:API_KEY` silently
+  misparses. envpkt warns at boot on a non-shell-safe separator but does not reject it.
+- A per-entry `namespace` overrides the file-level prefix; `""` opts out entirely.
+- `from_key` references stay logical regardless of namespace, so an alias can
+  bridge a namespaced canonical value to a plain legacy name (alias sets `namespace = ""`).
+- `BootResult.envNames` maps each logical key → its injected wire name.
+
 ## CLI Command Reference
 
 See `references/quick-reference.md` for a compact cheat sheet.
@@ -327,9 +358,12 @@ const result: Either<BootError, BootResult> = bootSafe({ inject: true })
 **BootResult**:
 
 - `audit: AuditResult` — full audit of all secrets
-- `injected: ReadonlyArray<string>` — keys successfully injected
-- `skipped: ReadonlyArray<string>` — keys that could not be resolved
-- `secrets: Readonly<Record<string, string>>` — resolved secret values
+- `injected: ReadonlyArray<string>` — keys successfully injected (logical names)
+- `skipped: ReadonlyArray<string>` — keys that could not be resolved (logical names)
+- `secrets: Readonly<Record<string, string>>` — resolved secret values, keyed by logical name
+- `envDefaults: Readonly<Record<string, string>>` — applied plaintext defaults, keyed by logical name
+- `overridden: ReadonlyArray<string>` — env defaults skipped because already set (logical names)
+- `envNames: Readonly<Record<string, string>>` — logical key → injected wire name (e.g. `API_KEY` → `CIV__API_KEY`); identity map when no namespace is set
 - `warnings: ReadonlyArray<string>` — non-fatal warnings
 - `configPath: string` — resolved path to the config file
 - `configSource: ConfigSource` — how the config was found: `"flag"` | `"env"` | `"cwd"` | `"search"`

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Standalone example configurations demonstrating envpkt features. All standalone 
 | `full-agent.toml`         | Full agent with lifecycle policies, callbacks, and tool integrations | `npx envpkt audit -c examples/full-agent.toml`           |
 | `ci-agent.toml`           | CI/CD deployment agent (GitHub, GHCR, Kubernetes)                    | `npx envpkt audit -c examples/ci-agent.toml`             |
 | `saas-integration.toml`   | SaaS billing service (Stripe, SendGrid, Redis)                       | `npx envpkt audit -c examples/saas-integration.toml`     |
+| `namespaced-agent.toml`   | Namespace prefix (`CIV__`) with a per-entry opt-out and alias bridge | `npx envpkt inspect -c examples/namespaced-agent.toml`   |
 | `catalog.toml`            | Shared secret catalog — team-owned metadata                          | `npx envpkt inspect -c examples/catalog.toml`            |
 | `agent-with-catalog.toml` | Agent referencing a shared catalog with capability narrowing         | `npx envpkt resolve -c examples/agent-with-catalog.toml` |
 | `sealed-agent.toml`       | Sealed packets — age-encrypted secrets safe to commit                | `npx envpkt inspect -c examples/sealed-agent.toml`       |

--- a/examples/namespaced-agent.toml
+++ b/examples/namespaced-agent.toml
@@ -1,0 +1,48 @@
+#:schema https://raw.githubusercontent.com/jordanburke/envpkt/main/schemas/envpkt.schema.json
+
+# envpkt with a namespace prefix.
+#
+# Every [secret.*]/[env.*] entry is INJECTED under a prefixed wire name
+# (CIV__API_KEY, CIV__LOG_LEVEL, ...), while the TOML keys you author and the
+# names shown in `audit`/`inspect` stay logical (API_KEY, LOG_LEVEL).
+# The prefix is applied only at the process.env boundary (boot, exec, env export).
+
+version = 1
+
+[namespace]
+prefix    = "CIV"
+separator = "__" # default; MUST be shell-safe ([A-Za-z0-9_]) — '.' and ':' break $VAR/export
+
+[identity]
+name = "civala-gateway"
+consumer = "service"
+description = "Namespaced credential set for the Civala API gateway"
+
+[lifecycle]
+stale_warning_days = 90
+
+[secret.API_KEY] # injected as CIV__API_KEY
+service = "civala"
+purpose = "Authenticates the gateway to the Civala core API"
+created = "2026-05-15"
+expires = "2027-05-15"
+last_rotated_at = "2026-05-15"
+rotation_url = "https://console.civala.com/keys"
+source = "vault"
+
+# Alias bridge: a `from_key` reference is always logical (independent of the
+# namespace), and this alias opts out of the prefix — so the same governed
+# value is also injected under the plain, un-prefixed name a legacy client reads.
+[secret.LEGACY_API_KEY] # injected as plain LEGACY_API_KEY
+from_key = "secret.API_KEY"
+namespace = ""
+purpose = "Un-prefixed name a legacy consumer still hardcodes"
+
+[env.LOG_LEVEL] # injected as CIV__LOG_LEVEL
+value = "info"
+purpose = "Gateway log verbosity"
+
+[env.REGION] # per-entry opt-out → injected as plain REGION
+value = "us-east-1"
+namespace = ""
+purpose = "Shared infra region, read by un-prefixed tooling"

--- a/schemas/envpkt.schema.json
+++ b/schemas/envpkt.schema.json
@@ -17,6 +17,24 @@
       "description": "Path to shared secret catalog (relative to this config file)",
       "type": "string"
     },
+    "namespace": {
+      "description": "Optional namespace/package prefix for injected environment variable names",
+      "type": "object",
+      "required": [
+        "prefix"
+      ],
+      "properties": {
+        "prefix": {
+          "description": "Namespace prefix applied to all injected env/secret names (e.g. 'CIV' -> CIV__API_KEY)",
+          "type": "string"
+        },
+        "separator": {
+          "default": "__",
+          "description": "Separator between prefix and key. Default '__' (shell-safe). Note: '.' and ':' are not valid in shell identifiers.",
+          "type": "string"
+        }
+      }
+    },
     "identity": {
       "description": "Identity and capabilities of the principal using this envpkt",
       "type": "object",
@@ -172,6 +190,10 @@
                   "type": "string"
                 }
               }
+            },
+            "namespace": {
+              "description": "Override the file-level namespace for this entry's injected name. Empty string opts out of any prefix.",
+              "type": "string"
             }
           }
         }
@@ -209,6 +231,10 @@
                   "type": "string"
                 }
               }
+            },
+            "namespace": {
+              "description": "Override the file-level namespace for this entry's injected name. Empty string opts out of any prefix.",
+              "type": "string"
             }
           }
         }

--- a/site/src/content/docs/cli/env-export.mdx
+++ b/site/src/content/docs/cli/env-export.mdx
@@ -52,6 +52,19 @@ Warnings are emitted to stderr so they don't pollute the `eval` output.
 
 Values containing single quotes are safely escaped (`'` becomes `'\''`).
 
+## Namespace
+
+If the config declares a [`[namespace]`](/reference/toml-schema/#namespace),
+the emitted `export` statements use the **wire name** (e.g. `CIV__API_KEY`), not
+the logical TOML key — so the variable you eval into your shell matches what the
+consumer reads. This is why the separator must be shell-safe (`_`/`__`):
+
+```bash
+$ envpkt env export
+export CIV__API_KEY='sk-...'
+export CIV__LOG_LEVEL='info'
+```
+
 ## Aliases
 
 Entries with `from_key` (see [Aliases](/reference/toml-schema/#aliases)) are

--- a/site/src/content/docs/cli/exec.mdx
+++ b/site/src/content/docs/cli/exec.mdx
@@ -48,6 +48,10 @@ envpkt exec --profile staging -- node server.js
 
 Requires [fnox integration](/integrations/fnox/) or [sealed packets](/getting-started/the-toml-file/) for secret injection.
 
+If the config declares a [`[namespace]`](/reference/toml-schema/#namespace), the
+subprocess receives each value under its **wire name** (e.g. `CIV__API_KEY`),
+matching what `boot()` would inject — not the logical TOML key.
+
 :::tip
 Need secrets in the **current** shell instead of a subprocess? Use [`envpkt env export`](/cli/env-export/) with `eval`.
 :::

--- a/site/src/content/docs/reference/library-api.mdx
+++ b/site/src/content/docs/reference/library-api.mdx
@@ -95,6 +95,12 @@ type BootResult = {
   readonly skipped: ReadonlyArray<string>
   readonly secrets: Readonly<Record<string, string>>
   readonly warnings: ReadonlyArray<string>
+  readonly envDefaults: Readonly<Record<string, string>>
+  readonly overridden: ReadonlyArray<string>
+  // Logical key → injected wire name (e.g. API_KEY → CIV__API_KEY).
+  // Identity map when no [namespace] is configured. secrets/envDefaults
+  // stay keyed by the logical name; this recovers the actual process.env name.
+  readonly envNames: Readonly<Record<string, string>>
   readonly configPath: string
   readonly configSource: ConfigSource
 }

--- a/site/src/content/docs/reference/toml-schema.mdx
+++ b/site/src/content/docs/reference/toml-schema.mdx
@@ -21,6 +21,43 @@ Enable editor autocompletion by adding the schema directive on line 1:
 | `version` | `number` | Yes      | Schema version number (currently `1`)                   |
 | `catalog` | `string` | No       | Path to shared secret catalog (relative to config file) |
 
+## `[namespace]` Section
+
+Optional. Prefixes the **injected** environment variable name for every
+`[secret.*]` and `[env.*]` entry, without changing the TOML keys you author or
+the names shown in audit/inspect. The TOML key stays the logical name; the
+prefix is applied only at the `process.env` boundary (`boot()`, `exec`, `env export`).
+
+| Field       | Type     | Required | Description                                                                                |
+| ----------- | -------- | -------- | ------------------------------------------------------------------------------------------ |
+| `prefix`    | `string` | Yes      | Prefix applied to injected names (e.g. `CIV` → `CIV__API_KEY`)                             |
+| `separator` | `string` | No       | Separator between prefix and key. Default `__`. **Must be shell-safe** — see warning below |
+
+```toml
+[namespace]
+prefix    = "CIV"
+separator = "__"   # optional, default
+
+[secret.API_KEY]   # injected as CIV__API_KEY
+service = "example"
+
+[env.LOG_LEVEL]    # injected as CIV__LOG_LEVEL
+value = "info"
+```
+
+:::caution[Use a shell-safe separator]
+A POSIX shell identifier may contain only `[A-Za-z0-9_]`. The default `__` is
+safe. `.` and `:` are **not** valid in shell variable names — `$CIV.API_KEY`
+fails to parse and `$CIV:API_KEY` silently misparses as a substring expansion.
+envpkt emits a boot warning if the separator isn't shell-safe, but does not
+reject it. Stick with `_` or `__` unless every consumer reads `process.env`
+directly (never via the shell).
+:::
+
+A logical key keeps its canonical name everywhere internal (audit, `from_key`
+references, fnox lookup, catalog merge); only the injected/exported name is
+prefixed. `BootResult.envNames` maps each logical key to its wire name.
+
 ## `[identity]` Section
 
 Identity and capabilities.
@@ -58,18 +95,20 @@ Per-secret metadata. Each key corresponds to an environment variable name.
 | `from_key`        | `string`        | No       | Alias       | Reference another secret entry (format: `"secret.<KEY>"`) — see [Aliases](#aliases) |
 | `required`        | `boolean`       | No       | Enforcement | Whether secret is required for operation                                            |
 | `tags`            | `object`        | No       | Enforcement | Key-value tags for grouping/filtering                                               |
+| `namespace`       | `string`        | No       | Enforcement | Override the file-level `[namespace]` prefix for this entry. `""` opts out entirely |
 
 ## `[env.<KEY>]` Sections
 
 Plaintext environment defaults. Each key corresponds to an environment variable. These are non-secret values that are safe to commit — use `[secret.*]` for sensitive credentials.
 
-| Field      | Type     | Required           | Description                                                                   |
-| ---------- | -------- | ------------------ | ----------------------------------------------------------------------------- |
-| `value`    | `string` | Yes unless aliased | Default value for this env variable — mutually exclusive with `from_key`      |
-| `from_key` | `string` | No                 | Reference another env entry (format: `"env.<KEY>"`) — see [Aliases](#aliases) |
-| `purpose`  | `string` | No                 | Why this env var exists                                                       |
-| `comment`  | `string` | No                 | Free-form annotation or note                                                  |
-| `tags`     | `object` | No                 | Key-value tags for grouping/filtering                                         |
+| Field       | Type     | Required           | Description                                                                   |
+| ----------- | -------- | ------------------ | ----------------------------------------------------------------------------- |
+| `value`     | `string` | Yes unless aliased | Default value for this env variable — mutually exclusive with `from_key`      |
+| `from_key`  | `string` | No                 | Reference another env entry (format: `"env.<KEY>"`) — see [Aliases](#aliases) |
+| `purpose`   | `string` | No                 | Why this env var exists                                                       |
+| `comment`   | `string` | No                 | Free-form annotation or note                                                  |
+| `tags`      | `object` | No                 | Key-value tags for grouping/filtering                                         |
+| `namespace` | `string` | No                 | Override the file-level `[namespace]` prefix for this entry. `""` opts out    |
 
 ```toml
 [env.NODE_ENV]
@@ -138,6 +177,24 @@ visible. Status (expiration, health) is inherited from the target — an alias
 is healthy iff its target is healthy.
 
 `envpkt audit --all` includes env default drift alongside secret health. Use `envpkt audit --env-only` to see only env defaults.
+
+**Aliases + namespace:** a `from_key` reference is always the **logical** key
+(`"secret.API_KEY"`), independent of any namespace. The alias is injected under
+its _own_ namespace resolution, so it can bridge a namespaced canonical value to
+a different injected name — e.g. expose a namespaced secret under a plain,
+un-prefixed legacy name:
+
+```toml
+[namespace]
+prefix = "CIV"
+
+[secret.API_KEY]                 # injected as CIV__API_KEY
+service = "example"
+
+[secret.LEGACY_API_KEY]
+from_key  = "secret.API_KEY"     # value copied from API_KEY
+namespace = ""                   # injected as plain LEGACY_API_KEY
+```
 
 ## `[lifecycle]` Section
 

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -236,8 +236,12 @@ const runEnvExport = (options: ExportOptions): void => {
         console.error(`${YELLOW}Warning:${RESET} ${warning}`)
       })
 
+      // Emit under the namespaced wire name (boot.envNames), not the logical key,
+      // so `eval "$(envpkt env export)"` sets the variable the consumer actually reads.
+      const wireName = (key: string): string => boot.envNames[key] ?? key
+
       Object.entries(boot.envDefaults).forEach(([key, value]) => {
-        console.log(`export ${key}='${shellEscape(value)}'`)
+        console.log(`export ${wireName(key)}='${shellEscape(value)}'`)
       })
 
       // Emit env entries that boot skipped (already in process.env).
@@ -251,15 +255,16 @@ const runEnvExport = (options: ExportOptions): void => {
             boot.overridden.forEach((key) => {
               if (!(key in envEntries)) return
               const entry = envEntries[key]!
-              const value = entry.value ?? process.env[key] ?? ""
-              console.log(`export ${key}='${shellEscape(value)}'`)
+              const name = wireName(key)
+              const value = entry.value ?? process.env[name] ?? ""
+              console.log(`export ${name}='${shellEscape(value)}'`)
             })
           },
         )
       }
 
       Object.entries(boot.secrets).forEach(([key, value]) => {
-        console.log(`export ${key}='${shellEscape(value)}'`)
+        console.log(`export ${wireName(key)}='${shellEscape(value)}'`)
       })
     },
   )

--- a/src/cli/commands/exec.ts
+++ b/src/cli/commands/exec.ts
@@ -72,19 +72,22 @@ export const runExec = (args: ReadonlyArray<string>, options: ExecOptions): void
     console.error(`${YELLOW}Warning:${RESET} ${warning}`)
   })
 
-  // Build environment: current env + env defaults + resolved secrets
+  // Build environment: current env + env defaults + resolved secrets.
+  // Inject under the namespaced wire name (boot.envNames), not the logical key.
   const env = { ...process.env }
+  const wireName = (key: string): string => boot.envNames[key] ?? key
 
-  // Apply env defaults (only if key not already set)
+  // Apply env defaults (only if the wire name is not already set)
   Object.entries(boot.envDefaults).forEach(([key, value]) => {
-    if (!(key in env)) {
-      env[key] = value
+    const name = wireName(key)
+    if (!(name in env)) {
+      env[name] = value
     }
   })
 
   // Apply secrets (always override)
   Object.entries(boot.secrets).forEach(([key, value]) => {
-    env[key] = value
+    env[wireName(key)] = value
   })
 
   // Execute the command

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -1,5 +1,6 @@
 import { $, Cond, Do, List, Map as FMap, Option, Set as FSet } from "functype"
 
+import { makeEnvNamer } from "./namespace.js"
 import type { EnvpktConfig } from "./schema.js"
 import type {
   AliasTable,
@@ -245,6 +246,11 @@ export const computeEnvAudit = (
 ): EnvAuditResult => {
   const envEntries = config.env ?? {}
 
+  // The live environment holds wire names (e.g. CIV__LOG_LEVEL), so drift is
+  // measured against the namespaced name, not the logical key.
+  const namer = makeEnvNamer(config)
+  const envWire = (key: string): string => namer(key, envEntries[key]?.namespace)
+
   const resolveEffectiveDefault = (entry: NonNullable<EnvpktConfig["env"]>[string]): string => {
     const viaAlias = Do(function* (): Generator<Option<unknown>, string, never> {
       const fk = yield* $(Option(entry.from_key))
@@ -256,7 +262,7 @@ export const computeEnvAudit = (
   }
 
   const entries = Object.entries(envEntries).map(([key, entry]) => {
-    const currentValue = env[key]
+    const currentValue = env[envWire(key)]
     const effectiveDefault = resolveEffectiveDefault(entry)
 
     const status: EnvDriftStatus = Cond.of<EnvDriftStatus>()

--- a/src/core/boot.ts
+++ b/src/core/boot.ts
@@ -15,6 +15,7 @@ import { computeAudit } from "./audit.js"
 import { resolveConfig } from "./catalog.js"
 import { expandPath, loadConfig, resolveConfigPath } from "./config.js"
 import { resolveKeyPath } from "./keygen.js"
+import { isShellSafeSeparator, makeEnvNamer } from "./namespace.js"
 import { unsealSecrets } from "./seal.js"
 import type { AuditResult, BootError, BootOptions, BootResult, ConfigSource, EnvpktConfig } from "./types.js"
 
@@ -142,6 +143,20 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
         const secretEntries = config.secret ?? {}
         const envEntries = config.env ?? {}
 
+        // Namespace boundary: internal records stay keyed by the logical name;
+        // only process.env reads/writes use the namespaced wire name. Per-entry
+        // `namespace` overrides the file-level prefix ("" opts out).
+        const namer = makeEnvNamer(config)
+        const secretEnv = (key: string): string => namer(key, secretEntries[key]?.namespace)
+        const envEnv = (key: string): string => namer(key, envEntries[key]?.namespace)
+
+        // Logical → wire name map for every known key, surfaced on BootResult so
+        // shell-facing consumers (exec, env export) inject under the real name.
+        const envNames: Record<string, string> = {
+          ...Object.fromEntries(Object.keys(envEntries).map((k) => [k, envEnv(k)])),
+          ...Object.fromEntries(Object.keys(secretEntries).map((k) => [k, secretEnv(k)])),
+        }
+
         // Separate alias from non-alias entries. Aliases carry no value of
         // their own; they copy from their target after the real entries resolve.
         const nonAliasSecretEntries = Object.fromEntries(
@@ -184,10 +199,19 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
           // Phase 0: apply env defaults + misclassification check
           warnings.push(...checkEnvMisclassification(config))
 
+          // Flag a namespace separator that would break shell consumers (e.g. '.', ':').
+          // Non-fatal: injection still works for process.env-based consumers.
+          const nsSeparator = config.namespace?.separator
+          if (nsSeparator !== undefined && !isShellSafeSeparator(nsSeparator)) {
+            warnings.push(
+              `[namespace] separator "${nsSeparator}" is not shell-safe — injected names won't be usable via shell $VAR/export. Use '_' or '__'.`,
+            )
+          }
+
           // Non-alias env defaults: inject literal values only if process.env[key] is unset
           const envDefaults: Record<string, string> = Object.fromEntries(
             nonAliasEnvEntries.flatMap(([key, entry]) =>
-              Option(process.env[key]).fold<ReadonlyArray<readonly [string, string]>>(
+              Option(process.env[envEnv(key)]).fold<ReadonlyArray<readonly [string, string]>>(
                 () =>
                   Option(entry.value).fold<ReadonlyArray<readonly [string, string]>>(
                     () => [],
@@ -198,7 +222,7 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
             ),
           )
           const overridden: string[] = nonAliasEnvEntries.flatMap(([key]) =>
-            Option(process.env[key]).fold<string[]>(
+            Option(process.env[envEnv(key)]).fold<string[]>(
               () => [],
               () => [key],
             ),
@@ -206,7 +230,7 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
 
           if (inject) {
             Object.entries(envDefaults).forEach(([key, value]) => {
-              process.env[key] = value
+              process.env[envEnv(key)] = value
             })
           }
 
@@ -304,14 +328,14 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
           aliasEnvKeys.forEach((aliasKey) => {
             const entry = aliasTable.entries.get(`env.${aliasKey}`)
             if (!entry) return
-            if (process.env[aliasKey] !== undefined) {
+            if (process.env[envEnv(aliasKey)] !== undefined) {
               overridden.push(aliasKey)
               return
             }
             const targetEntry = envEntries[entry.targetKey]
             if (targetEntry?.value === undefined) return
             // Prefer the already-injected/overriding value so alias tracks its target at runtime
-            const resolvedTarget = process.env[entry.targetKey] ?? targetEntry.value
+            const resolvedTarget = process.env[envEnv(entry.targetKey)] ?? targetEntry.value
             envDefaults[aliasKey] = resolvedTarget
           })
           /* eslint-enable functype/prefer-map */
@@ -319,10 +343,10 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
           if (inject) {
             // Inject env alias defaults (and any env defaults added by the alias pass)
             Object.entries(envDefaults).forEach(([key, value]) => {
-              process.env[key] ??= value
+              process.env[envEnv(key)] ??= value
             })
             Object.entries(secrets).forEach(([key, value]) => {
-              process.env[key] = value
+              process.env[secretEnv(key)] = value
             })
           }
 
@@ -334,6 +358,7 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
             warnings: warnings as ReadonlyArray<string>,
             envDefaults: envDefaults as Readonly<Record<string, string>>,
             overridden: overridden as ReadonlyArray<string>,
+            envNames: envNames as Readonly<Record<string, string>>,
             configPath,
             configSource,
           }

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,5 +1,6 @@
 import { List, Option, Set as FSet } from "functype"
 
+import { makeEnvNamer } from "./namespace.js"
 import type { ConfidenceLevel, MatchResult } from "./patterns.js"
 import { scanEnv } from "./patterns.js"
 import type { EnvpktConfig } from "./types.js"
@@ -71,15 +72,25 @@ export const envCheck = (config: EnvpktConfig, env: Readonly<Record<string, stri
   const metaKeys = Object.keys(secretEntries)
   const metaKeysSet = FSet(metaKeys)
 
+  // Namespace boundary: the live environment holds wire names (e.g. CIV__API_KEY),
+  // so presence checks and the tracked-key set must use wire names too. References
+  // (from_key) stay logical — a target's presence is checked at the target's wire name.
+  const namer = makeEnvNamer(config)
+  const envDefaultsForWire = config.env ?? {}
+  const secretWire = (key: string): string => namer(key, secretEntries[key]?.namespace)
+  const envWire = (key: string): string => namer(key, envDefaultsForWire[key]?.namespace)
+
+  const isPresentAt = (wire: string): boolean => env[wire] !== undefined && env[wire] !== ""
+
   // A secret entry is "satisfied" if its canonical name is set, OR (for aliases)
   // its target name is set — because at boot the alias will copy from target.
   const isSecretPresent = (key: string): boolean => {
-    if (env[key] !== undefined && env[key] !== "") return true
+    if (isPresentAt(secretWire(key))) return true
     const meta = secretEntries[key]
     if (meta?.from_key === undefined) return false
     return parseAliasRef(meta.from_key, "secret").fold(
       () => false,
-      (targetKey) => env[targetKey] !== undefined && env[targetKey] !== "",
+      (targetKey) => isPresentAt(secretWire(targetKey)),
     )
   }
 
@@ -97,12 +108,12 @@ export const envCheck = (config: EnvpktConfig, env: Readonly<Record<string, stri
   // Direction 1b: [env.*] keys → check if present (non-secret defaults; aliases satisfied by target)
   const envDefaults = config.env ?? {}
   const isEnvPresent = (key: string): boolean => {
-    if (env[key] !== undefined && env[key] !== "") return true
+    if (isPresentAt(envWire(key))) return true
     const meta = envDefaults[key]
     if (meta?.from_key === undefined) return false
     return parseAliasRef(meta.from_key, "env").fold(
       () => false,
-      (targetKey) => env[targetKey] !== undefined && env[targetKey] !== "",
+      (targetKey) => isPresentAt(envWire(targetKey)),
     )
   }
 
@@ -119,8 +130,10 @@ export const envCheck = (config: EnvpktConfig, env: Readonly<Record<string, stri
       }
     })
 
-  // Keys considered "tracked" = secrets ∪ env defaults (after dedup above)
-  const trackedKeys = FSet([...metaKeys, ...envDefaultEntries.map((e) => e.envVar)])
+  // Keys considered "tracked" = secrets ∪ env defaults (after dedup above).
+  // Use wire names so credential-shaped env vars injected under a namespace
+  // (e.g. CIV__API_KEY) match their tracking entry instead of looking untracked.
+  const trackedKeys = FSet([...metaKeys.map(secretWire), ...envDefaultEntries.map((e) => envWire(e.envVar))])
 
   // Direction 2: env vars → find credential-shaped vars not in TOML
   const envMatches = scanEnv(env)

--- a/src/core/namespace.ts
+++ b/src/core/namespace.ts
@@ -1,0 +1,44 @@
+import type { EnvpktConfig } from "./types.js"
+
+const DEFAULT_SEPARATOR = "__"
+
+const SHELL_SAFE_SEPARATOR_RE = /^[A-Za-z0-9_]+$/
+
+/**
+ * A separator is shell-safe when the resulting wire name is still a valid POSIX
+ * shell identifier. Only `[A-Za-z0-9_]` qualify — `.` and `:` (and empties)
+ * break `export NAME=` / `$NAME` and must be flagged.
+ */
+export const isShellSafeSeparator = (separator: string): boolean => SHELL_SAFE_SEPARATOR_RE.test(separator)
+
+/**
+ * Build the logical-key → wire-name transform for a config.
+ *
+ * The wire name is what gets written to / read from `process.env`. It is the
+ * only place a namespace prefix is applied — internal records (audit, aliases,
+ * fnox lookup) stay keyed by the canonical logical name.
+ *
+ * A per-entry namespace overrides the file-level prefix; an explicit empty
+ * string opts out (`"" ?? filePrefix` → `""`, a falsy prefix = no prefix).
+ *
+ * The default separator is `__` because it is the only namespace separator
+ * valid in a POSIX shell identifier (`.`/`:` break shell `export`/`$VAR`).
+ */
+export const makeEnvNamer = (config: EnvpktConfig): ((logicalKey: string, entryNamespace?: string) => string) => {
+  const filePrefix = config.namespace?.prefix
+  const separator = config.namespace?.separator ?? DEFAULT_SEPARATOR
+  return (logicalKey, entryNamespace) => {
+    const prefix = entryNamespace ?? filePrefix
+    return prefix ? `${prefix}${separator}${logicalKey}` : logicalKey
+  }
+}
+
+/**
+ * Dotted display form (e.g. `CIV.API_KEY`) for human/agent-facing output —
+ * format, MCP, and audit. Never use this for injection; the wire name uses the
+ * shell-safe separator instead.
+ */
+export const displayName = (config: EnvpktConfig, logicalKey: string, entryNamespace?: string): string => {
+  const prefix = entryNamespace ?? config.namespace?.prefix
+  return prefix ? `${prefix}.${logicalKey}` : logicalKey
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -43,6 +43,25 @@ export type AgentIdentity = Identity
 /** @deprecated Use `IdentitySchema` instead */
 export const AgentIdentitySchema = IdentitySchema
 
+// --- Namespace ---
+
+export const NamespaceSchema = Type.Object(
+  {
+    prefix: Type.String({
+      description: "Namespace prefix applied to all injected env/secret names (e.g. 'CIV' -> CIV__API_KEY)",
+    }),
+    separator: Type.Optional(
+      Type.String({
+        default: "__",
+        description:
+          "Separator between prefix and key. Default '__' (shell-safe). Note: '.' and ':' are not valid in shell identifiers.",
+      }),
+    ),
+  },
+  { description: "Optional namespace/package prefix for injected environment variable names" },
+)
+export type Namespace = Static<typeof NamespaceSchema>
+
 // --- Secret Metadata ---
 
 export const SecretMetaSchema = Type.Object(
@@ -89,6 +108,12 @@ export const SecretMetaSchema = Type.Object(
     required: Type.Optional(Type.Boolean({ description: "Whether this secret is required for operation" })),
     tags: Type.Optional(
       Type.Record(Type.String(), Type.String(), { description: "Key-value tags for grouping and filtering" }),
+    ),
+    namespace: Type.Optional(
+      Type.String({
+        description:
+          "Override the file-level namespace for this entry's injected name. Empty string opts out of any prefix.",
+      }),
     ),
   },
   { description: "Metadata about a single secret" },
@@ -148,6 +173,12 @@ export const EnvMetaSchema = Type.Object(
     tags: Type.Optional(
       Type.Record(Type.String(), Type.String(), { description: "Key-value tags for grouping and filtering" }),
     ),
+    namespace: Type.Optional(
+      Type.String({
+        description:
+          "Override the file-level namespace for this entry's injected name. Empty string opts out of any prefix.",
+      }),
+    ),
   },
   { description: "Metadata for a plaintext environment default (non-secret)" },
 )
@@ -161,6 +192,7 @@ export const EnvpktConfigSchema = Type.Object(
     catalog: Type.Optional(
       Type.String({ description: "Path to shared secret catalog (relative to this config file)" }),
     ),
+    namespace: Type.Optional(NamespaceSchema),
     identity: Type.Optional(IdentitySchema),
     secret: Type.Optional(
       Type.Record(Type.String(), SecretMetaSchema, {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,6 +11,7 @@ export type {
   EnvpktConfig,
   Identity,
   LifecycleConfig,
+  Namespace,
   SecretMeta,
   ToolsConfig,
 } from "./schema.js"
@@ -212,6 +213,13 @@ export type BootResult = {
   readonly warnings: ReadonlyArray<string>
   readonly envDefaults: Readonly<Record<string, string>>
   readonly overridden: ReadonlyArray<string>
+  /**
+   * Map of logical key → injected wire name (e.g. API_KEY → CIV__API_KEY).
+   * `secrets`/`envDefaults` stay keyed by the logical name; this is how
+   * shell-facing consumers (exec, env export) recover the actual process.env
+   * name. Identity map when no namespace is configured.
+   */
+  readonly envNames: Readonly<Record<string, string>>
   readonly configPath: string
   readonly configSource: ConfigSource
 }

--- a/test/cli/env.spec.ts
+++ b/test/cli/env.spec.ts
@@ -257,6 +257,41 @@ describe("envpkt env export", () => {
     expect(result.status).toBe(0)
     expect(result.stdout).toContain("export MY_SECRET='sk-test-secret-value'")
   })
+
+  it("emits the namespaced wire name for env defaults", () => {
+    const toml = `version = 1\n\n[namespace]\nprefix = "CIV"\n\n[env.LOG_LEVEL]\nvalue = "info"\n`
+    writeFileSync(join(tmpDir, "envpkt.toml"), toml)
+
+    const result = run(["env", "export"], { cwd: tmpDir })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("export CIV__LOG_LEVEL='info'")
+    expect(result.stdout).not.toContain("export LOG_LEVEL='info'")
+  })
+
+  it.skipIf(!ageInstalled)("emits the namespaced wire name for sealed secrets", () => {
+    const keygenOutput = execFileSync("age-keygen", [], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" })
+    const recipient = keygenOutput
+      .split("\n")
+      .find((l) => l.startsWith("# public key:"))!
+      .replace("# public key: ", "")
+      .trim()
+    writeFileSync(join(tmpDir, "identity.txt"), keygenOutput)
+
+    const encrypted = execFileSync("age", ["-r", recipient, "-a"], {
+      input: "sk-test-secret-value",
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+
+    const toml = `version = 1\n\n[namespace]\nprefix = "CIV"\n\n[identity]\nname = "test"\nrecipient = "${recipient}"\nkey_file = "identity.txt"\n\n[secret.MY_SECRET]\nservice = "test"\nencrypted_value = """\n${encrypted}"""\n`
+    writeFileSync(join(tmpDir, "envpkt.toml"), toml)
+
+    const result = run(["env", "export"], { cwd: tmpDir })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("export CIV__MY_SECRET='sk-test-secret-value'")
+  })
 })
 
 describe("envpkt audit --format minimal", () => {

--- a/test/cli/exec.spec.ts
+++ b/test/cli/exec.spec.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+const __testDir = dirname(fileURLToPath(import.meta.url))
+const PROJECT_ROOT = resolve(__testDir, "../..")
+const CLI_SRC = resolve(PROJECT_ROOT, "src/cli/index.ts")
+const TSX = resolve(PROJECT_ROOT, "node_modules/.bin/tsx")
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "envpkt-exec-test-"))
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const run = (args: string[]): { stdout: string; status: number } => {
+  try {
+    const stdout = execFileSync(TSX, [CLI_SRC, ...args], {
+      cwd: tmpDir,
+      env: { ...process.env },
+      encoding: "utf-8",
+      timeout: 15000,
+    })
+    return { stdout, status: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; status?: number }
+    return { stdout: e.stdout ?? "", status: e.status ?? 1 }
+  }
+}
+
+describe("envpkt exec with namespace", () => {
+  it("injects env defaults into the child under the namespaced wire name", () => {
+    const toml = `version = 1\n\n[namespace]\nprefix = "CIV"\n\n[env.GREETING]\nvalue = "hello"\n`
+    writeFileSync(join(tmpDir, "envpkt.toml"), toml)
+
+    const result = run([
+      "exec",
+      "--skip-audit",
+      "--",
+      "node",
+      "-e",
+      'process.stdout.write(`${process.env.CIV__GREETING ?? "MISSING"}|${process.env.GREETING ?? "unset"}`)',
+    ])
+
+    expect(result.status).toBe(0)
+    // child sees the wire name, not the logical name
+    expect(result.stdout).toContain("hello|unset")
+  })
+})

--- a/test/core/audit.spec.ts
+++ b/test/core/audit.spec.ts
@@ -492,4 +492,32 @@ describe("computeEnvAudit", () => {
     const result = computeEnvAudit(config, { NODE_ENV: "production" })
     expect(result.entries[0]!.purpose).toBe("Runtime environment")
   })
+
+  it("reads the current value from the namespaced wire name", () => {
+    const config: EnvpktConfig = {
+      version: 1,
+      namespace: { prefix: "CIV" },
+      env: { LOG_LEVEL: { value: "info" } },
+    }
+
+    const result = computeEnvAudit(config, { CIV__LOG_LEVEL: "info" })
+    const entry = result.entries.find((e) => e.key === "LOG_LEVEL")
+
+    expect(entry?.status).toBe("default")
+    expect(entry?.currentValue).toBe("info")
+  })
+
+  it("reports overridden when the wire-name value differs from the default", () => {
+    const config: EnvpktConfig = {
+      version: 1,
+      namespace: { prefix: "CIV" },
+      env: { LOG_LEVEL: { value: "info" } },
+    }
+
+    const result = computeEnvAudit(config, { CIV__LOG_LEVEL: "debug" })
+    const entry = result.entries.find((e) => e.key === "LOG_LEVEL")
+
+    expect(entry?.status).toBe("overridden")
+    expect(entry?.currentValue).toBe("debug")
+  })
 })

--- a/test/core/boot.spec.ts
+++ b/test/core/boot.spec.ts
@@ -602,6 +602,349 @@ describe("bootSafe with aliases", () => {
   })
 })
 
+describe("bootSafe with namespace", () => {
+  it("injects an env default under the namespaced wire name, keeping BootResult logical", () => {
+    const configPath = writeConfig(
+      [`version = 1`, `[namespace]`, `prefix = "CIV"`, `[env.NS_LOG_LEVEL]`, `value = "info"`].join("\n"),
+    )
+
+    delete process.env["CIV__NS_LOG_LEVEL"]
+    delete process.env["NS_LOG_LEVEL"]
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        (boot) => {
+          // wire name in the environment, logical name in the result
+          expect(process.env["CIV__NS_LOG_LEVEL"]).toBe("info")
+          expect(process.env["NS_LOG_LEVEL"]).toBeUndefined()
+          expect(boot.envDefaults).toEqual({ NS_LOG_LEVEL: "info" })
+        },
+      )
+    } finally {
+      delete process.env["CIV__NS_LOG_LEVEL"]
+      delete process.env["NS_LOG_LEVEL"]
+    }
+  })
+
+  it("opts an entry out of the namespace with an empty per-entry namespace", () => {
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[namespace]`,
+        `prefix = "CIV"`,
+        `[env.NS_SHARED]`,
+        `value = "shared-val"`,
+        `namespace = ""`,
+      ].join("\n"),
+    )
+
+    delete process.env["CIV__NS_SHARED"]
+    delete process.env["NS_SHARED"]
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        (boot) => {
+          expect(process.env["NS_SHARED"]).toBe("shared-val")
+          expect(process.env["CIV__NS_SHARED"]).toBeUndefined()
+          expect(boot.envDefaults).toEqual({ NS_SHARED: "shared-val" })
+        },
+      )
+    } finally {
+      delete process.env["CIV__NS_SHARED"]
+      delete process.env["NS_SHARED"]
+    }
+  })
+
+  it("uses a per-entry namespace override for the wire name", () => {
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[namespace]`,
+        `prefix = "CIV"`,
+        `[env.NS_LEGACY]`,
+        `value = "legacy-val"`,
+        `namespace = "OLD"`,
+      ].join("\n"),
+    )
+
+    delete process.env["OLD__NS_LEGACY"]
+    delete process.env["CIV__NS_LEGACY"]
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        (boot) => {
+          expect(process.env["OLD__NS_LEGACY"]).toBe("legacy-val")
+          expect(process.env["CIV__NS_LEGACY"]).toBeUndefined()
+          expect(boot.envDefaults).toEqual({ NS_LEGACY: "legacy-val" })
+        },
+      )
+    } finally {
+      delete process.env["OLD__NS_LEGACY"]
+      delete process.env["CIV__NS_LEGACY"]
+    }
+  })
+
+  it("detects an override against the namespaced wire name", () => {
+    const configPath = writeConfig(
+      [`version = 1`, `[namespace]`, `prefix = "CIV"`, `[env.NS_PORT]`, `value = "3000"`].join("\n"),
+    )
+
+    delete process.env["NS_PORT"]
+    process.env["CIV__NS_PORT"] = "8080"
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        (boot) => {
+          expect(boot.overridden).toContain("NS_PORT")
+          expect(boot.envDefaults).toEqual({})
+          expect(process.env["CIV__NS_PORT"]).toBe("8080")
+        },
+      )
+    } finally {
+      delete process.env["CIV__NS_PORT"]
+      delete process.env["NS_PORT"]
+    }
+  })
+
+  it("warns when the namespace separator is not shell-safe", () => {
+    const configPath = writeConfig(
+      [`version = 1`, `[namespace]`, `prefix = "CIV"`, `separator = "."`, `[env.NS_DOT]`, `value = "v"`].join("\n"),
+    )
+
+    const result = bootSafe({ configPath, inject: false })
+    result.fold(
+      (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+      (boot) => {
+        expect(boot.warnings.some((w) => w.toLowerCase().includes("separator"))).toBe(true)
+      },
+    )
+  })
+
+  it("does not warn for the default shell-safe separator", () => {
+    const configPath = writeConfig(
+      [`version = 1`, `[namespace]`, `prefix = "CIV"`, `[env.NS_OK]`, `value = "v"`].join("\n"),
+    )
+
+    const result = bootSafe({ configPath, inject: false })
+    result.fold(
+      (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+      (boot) => {
+        expect(boot.warnings.some((w) => w.toLowerCase().includes("separator"))).toBe(false)
+      },
+    )
+  })
+
+  it("exposes a logical→wire name map in BootResult.envNames", () => {
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[namespace]`,
+        `prefix = "CIV"`,
+        `[secret.API_KEY]`,
+        `service = "x"`,
+        `[secret.SHARED]`,
+        `service = "y"`,
+        `namespace = ""`,
+        `[env.LOG_LEVEL]`,
+        `value = "info"`,
+      ].join("\n"),
+    )
+
+    const result = bootSafe({ configPath, inject: false })
+    result.fold(
+      (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+      (boot) => {
+        expect(boot.envNames["API_KEY"]).toBe("CIV__API_KEY")
+        expect(boot.envNames["LOG_LEVEL"]).toBe("CIV__LOG_LEVEL")
+        expect(boot.envNames["SHARED"]).toBe("SHARED")
+      },
+    )
+  })
+
+  it("an env alias inherits the file namespace for its own wire name", () => {
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[namespace]`,
+        `prefix = "CIV"`,
+        `[env.SERVICE_URL]`,
+        `value = "https://api.example.com"`,
+        `[env.LEGACY_URL]`,
+        `from_key = "env.SERVICE_URL"`,
+      ].join("\n"),
+    )
+
+    delete process.env["CIV__SERVICE_URL"]
+    delete process.env["CIV__LEGACY_URL"]
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        () => {
+          // both canonical and alias land under the file namespace
+          expect(process.env["CIV__SERVICE_URL"]).toBe("https://api.example.com")
+          expect(process.env["CIV__LEGACY_URL"]).toBe("https://api.example.com")
+        },
+      )
+    } finally {
+      delete process.env["CIV__SERVICE_URL"]
+      delete process.env["CIV__LEGACY_URL"]
+    }
+  })
+
+  it("an env alias can opt out to bridge a legacy un-prefixed name to a namespaced canonical value", () => {
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[namespace]`,
+        `prefix = "CIV"`,
+        `[env.SERVICE_URL]`,
+        `value = "https://api.example.com"`,
+        `[env.LEGACY_URL]`,
+        `from_key = "env.SERVICE_URL"`,
+        `namespace = ""`,
+      ].join("\n"),
+    )
+
+    delete process.env["CIV__SERVICE_URL"]
+    delete process.env["LEGACY_URL"]
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        () => {
+          // canonical stays namespaced; the opted-out alias bridges to the plain name
+          expect(process.env["CIV__SERVICE_URL"]).toBe("https://api.example.com")
+          expect(process.env["LEGACY_URL"]).toBe("https://api.example.com")
+          expect(process.env["CIV__LEGACY_URL"]).toBeUndefined()
+        },
+      )
+    } finally {
+      delete process.env["CIV__SERVICE_URL"]
+      delete process.env["LEGACY_URL"]
+    }
+  })
+
+  it.skipIf(!ageInstalled)("a sealed secret alias bridges to a namespaced canonical value when opted out", () => {
+    const keygenOutput = execFileSync("age-keygen", [], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" })
+    const recipient = keygenOutput
+      .split("\n")
+      .find((l) => l.startsWith("# public key:"))!
+      .replace("# public key: ", "")
+      .trim()
+    const identityPath = join(tmpDir, "identity.txt")
+    writeFileSync(identityPath, keygenOutput)
+
+    const ciphertext = ageEncrypt("canonical-value", recipient).fold(
+      () => "",
+      (v) => v,
+    )
+
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[namespace]`,
+        `prefix = "CIV"`,
+        `[identity]`,
+        `name = "test-alias-ns"`,
+        `recipient = "${recipient}"`,
+        `key_file = "identity.txt"`,
+        `[secret.API_KEY]`,
+        `service = "example"`,
+        `encrypted_value = """`,
+        ciphertext,
+        `"""`,
+        `[secret.LEGACY_API_KEY]`,
+        `from_key = "secret.API_KEY"`,
+        `namespace = ""`,
+      ].join("\n"),
+    )
+
+    delete process.env["CIV__API_KEY"]
+    delete process.env["LEGACY_API_KEY"]
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        (boot) => {
+          // BootResult stays logical; injection respects each entry's namespace
+          expect(boot.secrets["API_KEY"]).toBe("canonical-value")
+          expect(boot.secrets["LEGACY_API_KEY"]).toBe("canonical-value")
+          expect(process.env["CIV__API_KEY"]).toBe("canonical-value")
+          expect(process.env["LEGACY_API_KEY"]).toBe("canonical-value")
+        },
+      )
+    } finally {
+      delete process.env["CIV__API_KEY"]
+      delete process.env["LEGACY_API_KEY"]
+    }
+  })
+
+  it.skipIf(!ageInstalled)("injects a sealed secret under the namespaced wire name", () => {
+    const keygenOutput = execFileSync("age-keygen", [], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" })
+    const recipient = keygenOutput
+      .split("\n")
+      .find((l) => l.startsWith("# public key:"))!
+      .replace("# public key: ", "")
+      .trim()
+    const identityPath = join(tmpDir, "identity.txt")
+    writeFileSync(identityPath, keygenOutput)
+
+    const ciphertext = ageEncrypt("sealed-ns-value", recipient).fold(
+      () => "",
+      (v) => v,
+    )
+
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[namespace]`,
+        `prefix = "CIV"`,
+        `[identity]`,
+        `name = "test-ns"`,
+        `recipient = "${recipient}"`,
+        `key_file = "identity.txt"`,
+        `[secret.SEALED_NS]`,
+        `service = "test"`,
+        `encrypted_value = """`,
+        ciphertext,
+        `"""`,
+      ].join("\n"),
+    )
+
+    delete process.env["CIV__SEALED_NS"]
+    delete process.env["SEALED_NS"]
+
+    try {
+      const result = bootSafe({ configPath, inject: true })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        (boot) => {
+          expect(process.env["CIV__SEALED_NS"]).toBe("sealed-ns-value")
+          expect(process.env["SEALED_NS"]).toBeUndefined()
+          // BootResult stays logical
+          expect(boot.secrets["SEALED_NS"]).toBe("sealed-ns-value")
+          expect(boot.injected).toContain("SEALED_NS")
+        },
+      )
+    } finally {
+      delete process.env["CIV__SEALED_NS"]
+      delete process.env["SEALED_NS"]
+    }
+  })
+})
+
 describe("EnvpktBootError", () => {
   it("has descriptive message for FileNotFound", () => {
     const err = new EnvpktBootError({ _tag: "FileNotFound", path: "/missing" })

--- a/test/core/env.spec.ts
+++ b/test/core/env.spec.ts
@@ -174,3 +174,49 @@ describe("env core", () => {
     })
   })
 })
+
+describe("envCheck with namespace", () => {
+  it("treats a namespaced secret present under its wire name as tracked, not missing or untracked", () => {
+    const config: EnvpktConfig = {
+      version: 1,
+      namespace: { prefix: "CIV" },
+      secret: { API_KEY: { service: "stripe" } },
+    }
+    const env = { CIV__API_KEY: "sk-livetest1234567890" }
+
+    const result = envCheck(config, env)
+    const apiEntry = result.entries.toArray().find((e) => e.envVar === "API_KEY")
+
+    expect(apiEntry?.status).toBe("tracked")
+    expect(result.untracked_credentials).toBe(0)
+  })
+
+  it("treats a namespaced env default present under its wire name as tracked", () => {
+    const config: EnvpktConfig = {
+      version: 1,
+      namespace: { prefix: "CIV" },
+      env: { LOG_LEVEL: { value: "info" } },
+    }
+    const env = { CIV__LOG_LEVEL: "debug" }
+
+    const result = envCheck(config, env)
+    const entry = result.entries.toArray().find((e) => e.envVar === "LOG_LEVEL")
+
+    expect(entry?.status).toBe("tracked")
+  })
+
+  it("honors a per-entry opt-out: a plain wire name satisfies an opted-out secret", () => {
+    const config: EnvpktConfig = {
+      version: 1,
+      namespace: { prefix: "CIV" },
+      secret: { SHARED_TOKEN: { service: "svc", namespace: "" } },
+    }
+    const env = { SHARED_TOKEN: "sk-livetest1234567890" }
+
+    const result = envCheck(config, env)
+    const entry = result.entries.toArray().find((e) => e.envVar === "SHARED_TOKEN")
+
+    expect(entry?.status).toBe("tracked")
+    expect(result.untracked_credentials).toBe(0)
+  })
+})

--- a/test/core/namespace.spec.ts
+++ b/test/core/namespace.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import { displayName, isShellSafeSeparator, makeEnvNamer } from "../../src/core/namespace.js"
+import type { EnvpktConfig } from "../../src/core/types.js"
+
+const cfg = (namespace?: EnvpktConfig["namespace"]): EnvpktConfig => ({ version: 1, namespace })
+
+describe("makeEnvNamer", () => {
+  it("returns the logical key unchanged when no namespace is configured", () => {
+    const namer = makeEnvNamer(cfg())
+    expect(namer("API_KEY")).toBe("API_KEY")
+  })
+
+  it("prefixes with the file-level namespace and default '__' separator", () => {
+    const namer = makeEnvNamer(cfg({ prefix: "CIV" }))
+    expect(namer("API_KEY")).toBe("CIV__API_KEY")
+  })
+
+  it("uses a custom separator when provided", () => {
+    const namer = makeEnvNamer(cfg({ prefix: "CIV", separator: "_" }))
+    expect(namer("API_KEY")).toBe("CIV_API_KEY")
+  })
+
+  it("lets a per-entry namespace override the file-level prefix", () => {
+    const namer = makeEnvNamer(cfg({ prefix: "CIV" }))
+    expect(namer("LEGACY_KEY", "OLD")).toBe("OLD__LEGACY_KEY")
+  })
+
+  it("treats an empty per-entry namespace as an explicit opt-out", () => {
+    const namer = makeEnvNamer(cfg({ prefix: "CIV" }))
+    expect(namer("SHARED_TOKEN", "")).toBe("SHARED_TOKEN")
+  })
+
+  it("inherits the file-level separator for per-entry overrides", () => {
+    const namer = makeEnvNamer(cfg({ prefix: "CIV", separator: "_" }))
+    expect(namer("LEGACY_KEY", "OLD")).toBe("OLD_LEGACY_KEY")
+  })
+
+  it("applies a per-entry namespace even when no file-level prefix exists", () => {
+    const namer = makeEnvNamer(cfg())
+    expect(namer("LEGACY_KEY", "OLD")).toBe("OLD__LEGACY_KEY")
+  })
+})
+
+describe("displayName", () => {
+  it("returns the logical key unchanged when no namespace is configured", () => {
+    expect(displayName(cfg(), "API_KEY")).toBe("API_KEY")
+  })
+
+  it("renders the dotted form regardless of the wire separator", () => {
+    expect(displayName(cfg({ prefix: "CIV", separator: "__" }), "API_KEY")).toBe("CIV.API_KEY")
+  })
+
+  it("honors a per-entry override in the dotted display form", () => {
+    expect(displayName(cfg({ prefix: "CIV" }), "LEGACY_KEY", "OLD")).toBe("OLD.LEGACY_KEY")
+  })
+
+  it("opts out of the dotted prefix for an empty per-entry namespace", () => {
+    expect(displayName(cfg({ prefix: "CIV" }), "SHARED_TOKEN", "")).toBe("SHARED_TOKEN")
+  })
+})
+
+describe("isShellSafeSeparator", () => {
+  it("accepts underscore separators", () => {
+    expect(isShellSafeSeparator("__")).toBe(true)
+    expect(isShellSafeSeparator("_")).toBe(true)
+  })
+
+  it("accepts alphanumeric separators", () => {
+    expect(isShellSafeSeparator("X")).toBe(true)
+  })
+
+  it("rejects a dot separator", () => {
+    expect(isShellSafeSeparator(".")).toBe(false)
+  })
+
+  it("rejects a colon separator", () => {
+    expect(isShellSafeSeparator(":")).toBe(false)
+  })
+
+  it("rejects an empty separator", () => {
+    expect(isShellSafeSeparator("")).toBe(false)
+  })
+})

--- a/test/core/schema.spec.ts
+++ b/test/core/schema.spec.ts
@@ -83,6 +83,26 @@ describe("EnvpktConfigSchema", () => {
     const config = { version: 1 }
     expect(configChecker.Check(config)).toBe(true)
   })
+
+  it("validates a config with a top-level namespace", () => {
+    const config = { version: 1, namespace: { prefix: "CIV", separator: "__" } }
+    expect(configChecker.Check(config)).toBe(true)
+  })
+
+  it("validates a namespace with only a prefix (separator optional)", () => {
+    const config = { version: 1, namespace: { prefix: "CIV" } }
+    expect(configChecker.Check(config)).toBe(true)
+  })
+
+  it("rejects a namespace with a non-string prefix", () => {
+    const config = { version: 1, namespace: { prefix: 123 } }
+    expect(configChecker.Check(config)).toBe(false)
+  })
+
+  it("rejects a namespace missing its prefix", () => {
+    const config = { version: 1, namespace: { separator: "__" } }
+    expect(configChecker.Check(config)).toBe(false)
+  })
 })
 
 describe("SecretMetaSchema", () => {
@@ -121,6 +141,18 @@ describe("SecretMetaSchema", () => {
     const meta = { service: "stripe", comment: "Rotated by ops team on Mondays" }
     expect(secretMetaChecker.Check(meta)).toBe(true)
   })
+
+  it("accepts a per-entry namespace override", () => {
+    expect(secretMetaChecker.Check({ namespace: "OLD" })).toBe(true)
+  })
+
+  it("accepts an empty per-entry namespace (opt-out)", () => {
+    expect(secretMetaChecker.Check({ namespace: "" })).toBe(true)
+  })
+
+  it("rejects a non-string per-entry namespace", () => {
+    expect(secretMetaChecker.Check({ namespace: 123 })).toBe(false)
+  })
 })
 
 describe("EnvMetaSchema", () => {
@@ -141,6 +173,14 @@ describe("EnvMetaSchema", () => {
       tags: { env: "prod" },
     }
     expect(envMetaChecker.Check(meta)).toBe(true)
+  })
+
+  it("accepts a per-entry namespace override", () => {
+    expect(envMetaChecker.Check({ value: "x", namespace: "OLD" })).toBe(true)
+  })
+
+  it("rejects a non-string per-entry namespace", () => {
+    expect(envMetaChecker.Check({ value: "x", namespace: 123 })).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Adds an optional `[namespace]` table that prefixes the **injected** environment variable name for every `[secret.*]`/`[env.*]` entry (e.g. `CIV__API_KEY`), while the TOML keys you author and the names shown in `audit`/`inspect` stay logical. The prefix is applied **only at the `process.env` boundary** — internal resolution (audit, `from_key` references, fnox lookup, catalog merge) stays keyed by the logical name.

Motivation: namespacing credentials for shell injection. The default separator is `__` because it's the only namespace separator valid in a POSIX shell identifier — `.` and `:` break `$VAR`/`export` (`.` fails to parse, `:` silently misparses as a substring expansion).

## What's included

**Schema**
- `[namespace]` with `prefix` (required) + `separator` (default `__`, must be shell-safe)
- per-entry `namespace` override on secret/env entries (`""` opts out)

**Core**
- `namespace.ts`: `makeEnvNamer` (logical → wire), `displayName`, `isShellSafeSeparator`
- `boot.ts`: applies the namer at all 7 `process.env` touch points, warns (non-fatal) on a non-shell-safe separator, and exposes the logical→wire map as `BootResult.envNames`
- `env.ts` / `audit.ts`: **bug fix** — `envCheck` and `computeEnvAudit` now read `process.env` by wire name; drift detection was wrong under a namespace

**CLI**
- `exec` + `env export`: **bug fix** — inject/emit under the wire name via `boot.envNames` instead of the logical key (shell injection was emitting the unprefixed name, defeating the purpose)

**References (`from_key`)**
- A reference is always logical and the alias resolves its *own* namespace, so an alias can bridge a namespaced canonical value to a plain legacy name by opting out (`namespace = ""`). Locked with tests.

**Docs / skill / examples**
- `[namespace]` schema reference + shell-safe-separator caution + alias-bridge note
- `env-export` / `exec` wire-name notes; synced stale `BootResult` in `library-api.mdx` + `SKILL.md`
- new `examples/namespaced-agent.toml` (prefix + per-entry opt-out + alias bridge; audits HEALTHY)

## Test plan

- `pnpm validate` → exit 0 (format, lint, typecheck, **514 tests**, schema, build)
- `pnpm docs:build` → 39 pages, clean
- Manually verified: `env export` emits `CIV__LOG_LEVEL` and opted-out `REGION`; `exec` child sees `CIV__GREETING`, not `GREETING`

🤖 Generated with [Claude Code](https://claude.com/claude-code)