### PR TITLE
ci: bump workflow actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
@@ -41,7 +41,7 @@ jobs:
         run: npm publish --provenance --access public
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
         env:


### PR DESCRIPTION
## Summary

The 0.11.7 publish run flagged that several workflow actions still run on **Node.js 20**. GitHub forces Node 24 for JS actions on **2026-06-16** and removes Node 20 on **2026-09-16**, so this bumps every affected action to its current Node 24 major.

| Action | Before | After | Runtime |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v5** | node24 |
| `actions/setup-node` | v4 | **v5** | node24 |
| `pnpm/action-setup` | v4 | **v6** | node24 |
| `softprops/action-gh-release` | v1 | **v3** | node24 |

## Notes

- ⚠️ `softprops/action-gh-release@v2` is **still node20** — only **v3** declares `using: node24`, so v3 is the required target (verified against each action's `action.yml`).
- Inputs in use remain supported across these majors: `node-version-file`, `cache`, `registry-url` (setup-node) and `generate_release_notes` (gh-release).
- `pnpm/action-setup` is used with no `version:` input; it auto-detects from the `packageManager` field (`pnpm@11.5.2`) in `package.json`, which v6 still supports.

## Test plan

- The PR's **Node.js CI** run exercises `checkout@v5`, `pnpm/action-setup@v6`, and `setup-node@v5` end-to-end (install + full validate).
- `action-gh-release@v3` only runs on a tag push; it's a low-risk bump for `generate_release_notes` and will be exercised on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)