### PR TITLE
feat: GitHub Actions CI injection (env github + Action + inline age key)

### DIFF
--- a/.claude/skills/envpkt/SKILL.md
+++ b/.claude/skills/envpkt/SKILL.md
@@ -264,12 +264,13 @@ See `references/quick-reference.md` for a compact cheat sheet.
 
 ### Operations
 
-| Command                    | Description                                        |
-| -------------------------- | -------------------------------------------------- |
-| `envpkt exec <command...>` | Pre-flight audit then execute with injected env    |
-| `envpkt seal`              | Encrypt secret values into config using age        |
-| `envpkt resolve`           | Resolve catalog references into flat config        |
-| `envpkt env export`        | Output `export` statements for eval-ing into shell |
+| Command                    | Description                                                            |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `envpkt exec <command...>` | Pre-flight audit then execute with injected env                        |
+| `envpkt seal`              | Encrypt secret values into config using age                            |
+| `envpkt resolve`           | Resolve catalog references into flat config                            |
+| `envpkt env export`        | Output `export` statements for eval-ing into shell                     |
+| `envpkt env github`        | Inject resolved secrets into `$GITHUB_ENV` (masked) for GitHub Actions |
 
 **exec options**: `-c <path>`, `--profile <profile>`, `--skip-audit` / `--no-check`, `--warn-only`, `--strict`
 
@@ -278,6 +279,17 @@ See `references/quick-reference.md` for a compact cheat sheet.
 **resolve options**: `-c <path>`, `-o <path>`, `--format toml|json`, `--dry-run`
 
 **env export options**: `-c <path>`, `--profile <profile>`, `--skip-audit`
+
+**env github options**: `-c <path>`, `--profile <profile>`, `--strict`. For GitHub Actions
+CI: emits `::add-mask::` for each secret (redacts it from the log) and appends heredoc
+assignments to `$GITHUB_ENV` (using namespaced wire names) so later job steps inherit them;
+env defaults are written but not masked. `--strict` exits with the audit code (1/2) after
+injecting. There is also a composite Action: `uses: jordanburke/envpkt@v1`.
+
+**CI age-key contract**: supply the age private key inline via the `ENVPKT_AGE_KEY` env var
+(e.g. a GitHub secret) — `boot()` materializes it to a `0600` temp file to decrypt sealed
+packets, no key file needed. Precedence: `identity.key_file` → `ENVPKT_AGE_KEY_FILE` →
+`ENVPKT_AGE_KEY` (inline) → `~/.envpkt/age-key.txt`.
 
 ### Secret Management (CRUD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-06-07
+
+### Added
+
+- **GitHub Actions CI injection.** New `envpkt env github` command resolves the credentials
+  in `envpkt.toml` and injects them into `$GITHUB_ENV` under their namespaced wire names, so
+  later steps in the job inherit them. Secret values are masked in the log via
+  `::add-mask::`; env defaults are written but not masked. `--strict` gates the build on the
+  pre-flight audit.
+- **Composite GitHub Action** (`action.yml`) — `uses: jordanburke/envpkt@v1` with inputs
+  `config` / `version` / `strict` / `profile`, wrapping `env github`.
+- **Inline age key for CI.** `boot()` now honors an inline `ENVPKT_AGE_KEY` (e.g. a CI
+  secret): it is materialized to a `0600` temp file to decrypt sealed packets and removed
+  after use, so no key file is needed in CI. Identity precedence:
+  `identity.key_file` → `ENVPKT_AGE_KEY_FILE` → `ENVPKT_AGE_KEY` (inline) →
+  `~/.envpkt/age-key.txt`.
+
+### Documentation
+
+- New GitHub Action integration page and `env github` CLI page; CI/CD guide updated to use
+  the Action; skill updated with the `env github` command and the `ENVPKT_AGE_KEY` contract.
+
+## [0.11.9] - 2026-06-07
+
+### Documentation
+
+- Add changelog entries for 0.11.7 and 0.11.8 (no functional change; published as a release).
+
 ## [0.11.8] - 2026-06-07
 
 ### Changed
@@ -329,6 +357,8 @@ Initial public release.
 - Shared secret catalog with the `resolve` command.
 - Secret value display, golden fixtures, and demo HTML generation.
 
+[0.12.0]: https://github.com/jordanburke/envpkt/compare/v0.11.9...v0.12.0
+[0.11.9]: https://github.com/jordanburke/envpkt/compare/v0.11.8...v0.11.9
 [0.11.8]: https://github.com/jordanburke/envpkt/compare/v0.11.7...v0.11.8
 [0.11.7]: https://github.com/jordanburke/envpkt/compare/v0.11.6...v0.11.7
 [0.11.6]: https://github.com/jordanburke/envpkt/compare/v0.11.5...v0.11.6

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,35 @@
+name: "envpkt"
+description: "Resolve envpkt.toml credentials into the job environment for GitHub Actions, with secret values masked in the log."
+author: "jordanburke"
+branding:
+  icon: "package"
+  color: "purple"
+
+inputs:
+  config:
+    description: "Path to envpkt.toml (defaults to envpkt's discovery: CWD, then ENVPKT_CONFIG, then the search chain)."
+    required: false
+  version:
+    description: "envpkt version to run via npx (e.g. 0.12.0). Defaults to the latest published version."
+    required: false
+    default: "latest"
+  strict:
+    description: "Fail the step if the pre-flight credential audit is not healthy."
+    required: false
+    default: "false"
+  profile:
+    description: "fnox profile to resolve secrets from (when using fnox)."
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    # Resolves sealed packets (via ENVPKT_AGE_KEY) / fnox, masks secret values with
+    # ::add-mask::, and appends them to $GITHUB_ENV so later steps in the job inherit them.
+    # Supply the age key as a secret on this step:  env: { ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }} }
+    - shell: bash
+      run: |
+        npx --yes "envpkt@${{ inputs.version }}" env github \
+          ${{ inputs.config && format('--config {0}', inputs.config) || '' }} \
+          ${{ inputs.strict == 'true' && '--strict' || '' }} \
+          ${{ inputs.profile && format('--profile {0}', inputs.profile) || '' }}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
             { slug: "cli/env-scan" },
             { slug: "cli/env-check" },
             { slug: "cli/env-export" },
+            { slug: "cli/env-github" },
             { slug: "cli/shell-hook" },
             { slug: "cli/mcp" },
           ],
@@ -56,6 +57,7 @@ export default defineConfig({
         {
           label: "Integrations",
           items: [
+            { slug: "integrations/github-action" },
             { slug: "integrations/fnox" },
             { slug: "integrations/mcp-server" },
             { slug: "integrations/shell-hooks" },

--- a/site/src/content/docs/cli/env-github.mdx
+++ b/site/src/content/docs/cli/env-github.mdx
@@ -1,0 +1,77 @@
+---
+title: envpkt env github
+description: Inject resolved secrets into $GITHUB_ENV for GitHub Actions, with values masked in the log
+---
+
+Resolve the credentials described in `envpkt.toml` and inject them into the GitHub Actions
+job environment — masking secret values in the log and writing them to `$GITHUB_ENV` so the
+rest of the job can use them. This is the CLI engine behind the [GitHub Action](/integrations/github-action/).
+
+## Usage
+
+```bash
+envpkt env github [options]
+```
+
+Run it as a step in a job; later steps in the same job inherit the variables:
+
+```yaml
+- run: npx envpkt env github --strict
+  env:
+    ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }}
+- run: ./build.sh # sees the resolved vars
+```
+
+## Options
+
+| Option                | Description                                          | Default       |
+| --------------------- | ---------------------------------------------------- | ------------- |
+| `-c, --config <path>` | Path to `envpkt.toml`                                | Auto-detected |
+| `--profile <profile>` | fnox profile to use                                  | —             |
+| `--strict`            | Exit non-zero if the pre-flight audit is not healthy | `false`       |
+
+## What it emits
+
+For each resolved entry, using the namespaced [wire name](/reference/toml-schema/#namespace):
+
+- **Secrets** (`[secret.*]`) — a `::add-mask::<value>` workflow command on **stdout** so
+  GitHub redacts the value everywhere in the log, then the assignment is appended to
+  `$GITHUB_ENV`.
+- **Env defaults** (`[env.*]`) — appended to `$GITHUB_ENV`. These are non-secret by design
+  and are **not** masked.
+
+Assignments use the multiline heredoc form, so values with newlines or special characters
+are safe:
+
+```bash
+$ envpkt env github       # (GITHUB_ENV pointed at the runner's env file)
+::add-mask::sk-live-...
+# appended to $GITHUB_ENV:
+CIV__API_KEY<<__ENVPKT_59bbd943__
+sk-live-...
+__ENVPKT_59bbd943__
+```
+
+When `$GITHUB_ENV` is not set (e.g. running locally), the assignments are printed to stdout
+with a warning instead — useful for previewing output off-runner.
+
+## Resolving secrets in CI
+
+Sealed (`encrypted_value`) packets are the typical CI source. Commit them to the repo and
+supply the age private key as a GitHub secret via **`ENVPKT_AGE_KEY`** — `boot()` materializes
+it to a private temp file to decrypt, no key file needed. Identity precedence:
+
+```
+identity.key_file  >  ENVPKT_AGE_KEY_FILE  >  ENVPKT_AGE_KEY (inline)  >  ~/.envpkt/age-key.txt
+```
+
+## Audit gate
+
+With `--strict`, the command exits with the audit's [exit code](/reference/exit-codes/)
+(`1` degraded, `2` critical) after injecting — failing the build on expired or missing
+credentials. Without `--strict` it always exits `0`.
+
+## See also
+
+- [GitHub Action](/integrations/github-action/) — the `uses: jordanburke/envpkt@v1` wrapper.
+- [`envpkt env export`](/cli/env-export/) — the shell-`eval` analog for local/non-GitHub use.

--- a/site/src/content/docs/guides/ci-cd.mdx
+++ b/site/src/content/docs/guides/ci-cd.mdx
@@ -56,32 +56,42 @@ Exit codes:
 
 ## GitHub Actions
 
-```yaml
-name: Credential Audit
-on:
-  schedule:
-    - cron: "0 9 * * 1" # Weekly Monday 9am
-  push:
-    paths:
-      - "envpkt.toml"
+The [`envpkt` GitHub Action](/integrations/github-action/) resolves your sealed credentials
+into the job environment (masked in the log) and, with `strict`, gates the build on
+credential health — no hand-rolled install steps:
 
+```yaml
 jobs:
-  audit:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+
+      - uses: jordanburke/envpkt@v1
         with:
-          node-version: 20
+          config: ./envpkt.toml
+          strict: "true"
+        env:
+          ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }}
 
-      - name: Install envpkt
-        run: npm install -g envpkt
+      - run: ./deploy.sh # sees resolved vars; secret values redacted in the log
+```
 
-      - name: Audit credentials
-        run: envpkt audit --strict --format json
+Commit sealed (`encrypted_value`) packets to the repo and supply the age private key as the
+`ENVPKT_AGE_KEY` secret — see the [GitHub Action](/integrations/github-action/) and
+[`env github`](/cli/env-github/) docs for the resolution model and masking details.
 
-      - name: Check drift
-        run: envpkt env check --strict
+### Audit-only (no injection)
+
+For a standalone health gate that doesn't inject anything, run the CLI directly:
+
+```yaml
+- uses: actions/checkout@v5
+- uses: actions/setup-node@v5
+  with:
+    node-version: 24
+- run: npx envpkt audit --strict --format json
+- run: npx envpkt env check --strict
 ```
 
 ## Fleet Scanning in CI

--- a/site/src/content/docs/integrations/github-action.mdx
+++ b/site/src/content/docs/integrations/github-action.mdx
@@ -1,0 +1,81 @@
+---
+title: GitHub Action
+description: Resolve envpkt.toml credentials into a GitHub Actions job, with secrets masked
+---
+
+The `envpkt` GitHub Action resolves the credentials described in `envpkt.toml` and injects
+them into the job environment — masking secret values in the log and writing them to
+`$GITHUB_ENV` so every later step in the job can use them. It's a thin wrapper over
+[`envpkt env github`](/cli/env-github/).
+
+## Quick start
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: jordanburke/envpkt@v1
+        with:
+          config: ./envpkt.toml
+          strict: "true"
+        env:
+          ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }}
+
+      - run: ./deploy.sh # sees the resolved variables; secret values redacted in the log
+```
+
+After the `envpkt` step, the secrets and env defaults from `envpkt.toml` are present in the
+environment for the rest of the job, under their [namespaced wire names](/reference/toml-schema/#namespace)
+(e.g. `CIV__API_KEY`).
+
+## Inputs
+
+| Input     | Description                                                        | Default  |
+| --------- | ------------------------------------------------------------------ | -------- |
+| `config`  | Path to `envpkt.toml` (otherwise envpkt's discovery chain is used) | —        |
+| `version` | envpkt version to run via `npx` (e.g. `0.12.0`)                    | `latest` |
+| `strict`  | Fail the step if the pre-flight credential audit is not healthy    | `false`  |
+| `profile` | fnox profile to resolve from (when using fnox)                     | —        |
+
+## Supplying the decryption key
+
+Sealed (`encrypted_value`) packets are the typical CI source: commit them to the repo
+(they're age-encrypted and safe to commit) and provide the **age private key** as a
+repository/organization secret named `ENVPKT_AGE_KEY` on the step's `env`:
+
+```yaml
+- uses: jordanburke/envpkt@v1
+  env:
+    ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }}
+```
+
+envpkt writes the inline key to a private (`0600`) temp file to decrypt and removes it
+afterwards — no key file needs to live in the repo or runner. Identity precedence:
+
+```
+identity.key_file  >  ENVPKT_AGE_KEY_FILE  >  ENVPKT_AGE_KEY (inline)  >  ~/.envpkt/age-key.txt
+```
+
+## Masking
+
+Every secret value is registered with GitHub via `::add-mask::` **before** it is written,
+so it is redacted everywhere in the job log. Env defaults (`[env.*]`) are non-secret by
+design and are not masked. Because masking and `$GITHUB_ENV` rely on a shell-safe variable
+name, keep any [`[namespace]`](/reference/toml-schema/#namespace) separator to `_`/`__`.
+
+## Audit gate
+
+With `strict: "true"`, the step fails (non-zero [exit code](/reference/exit-codes/)) when a
+credential is expired or otherwise unhealthy — a one-line pre-flight gate for your build.
+
+## Notes
+
+- **Node** is assumed present (GitHub-hosted runners ship it). To pin a version, add
+  `actions/setup-node` before the `envpkt` step.
+- For the **current shell** instead of a GitHub job (local dev, other CI), use
+  [`envpkt env export`](/cli/env-export/) with `eval`.
+- To run a single command with the credentials injected (without `$GITHUB_ENV`), use
+  [`envpkt exec`](/cli/exec/).

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -1,7 +1,9 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { randomBytes } from "node:crypto"
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 
 import type { Command } from "commander"
+import type { Either } from "functype"
 import { Option, Try } from "functype"
 
 import { bootSafe } from "../../core/boot.js"
@@ -9,10 +11,12 @@ import { resolveConfig } from "../../core/catalog.js"
 import { loadConfig, resolveConfigPath } from "../../core/config.js"
 import { envCheck, envScan, generateTomlFromScan } from "../../core/env.js"
 import { appendSection, removeSection, renameSection, updateSectionFields } from "../../core/toml-edit.js"
+import type { BootError, BootResult } from "../../core/types.js"
 import {
   BOLD,
   CYAN,
   DIM,
+  exitCodeForAudit,
   formatCheckJson,
   formatCheckTable,
   formatConfigSource,
@@ -44,6 +48,12 @@ type ExportOptions = {
   readonly config?: string
   readonly profile?: string
   readonly skipAudit?: boolean
+}
+
+type GithubOptions = {
+  readonly config?: string
+  readonly profile?: string
+  readonly strict?: boolean
 }
 
 type AddEnvOptions = {
@@ -215,57 +225,119 @@ const runEnvCheck = (options: CheckOptions): void => {
 
 const shellEscape = (value: string): string => value.replace(/'/g, "'\\''")
 
-const runEnvExport = (options: ExportOptions): void => {
-  const result = bootSafe({
+type EmitEntry = { readonly name: string; readonly value: string; readonly secret: boolean }
+
+/** Shared resolution for the emit commands (`export`, `github`): resolve without injecting. */
+const resolveForEmit = (options: {
+  readonly config?: string
+  readonly profile?: string
+}): Either<BootError, BootResult> =>
+  bootSafe({
     inject: false,
     configPath: options.config,
     profile: options.profile,
     warnOnly: true,
   })
 
-  result.fold(
+/**
+ * Flatten a resolved BootResult into the ordered (wire-name, value) pairs to emit:
+ * env defaults, then overridden env entries (value from config), then secrets (which
+ * override). `secret` marks values that consumers must redact (e.g. GitHub masking).
+ */
+const collectEmitEntries = (boot: BootResult): EmitEntry[] => {
+  const wireName = (key: string): string => boot.envNames[key] ?? key
+
+  const defaults: EmitEntry[] = Object.entries(boot.envDefaults).map(([key, value]) => ({
+    name: wireName(key),
+    value,
+    secret: false,
+  }))
+
+  // Env entries already set in the environment (boot skipped them); re-emit from config value.
+  const overridden: EmitEntry[] =
+    boot.overridden.length === 0
+      ? []
+      : loadConfig(boot.configPath).fold<EmitEntry[]>(
+          () => [],
+          (config) => {
+            const envEntries = config.env ?? {}
+            return boot.overridden.flatMap((key) => {
+              const entry = envEntries[key]
+              if (!entry) return []
+              const name = wireName(key)
+              return [{ name, value: entry.value ?? process.env[name] ?? "", secret: false }]
+            })
+          },
+        )
+
+  const secrets: EmitEntry[] = Object.entries(boot.secrets).map(([key, value]) => ({
+    name: wireName(key),
+    value,
+    secret: true,
+  }))
+
+  return [...defaults, ...overridden, ...secrets]
+}
+
+const emitWarnings = (boot: BootResult): void => {
+  const sourceMsg = formatConfigSource(boot.configPath, boot.configSource)
+  if (sourceMsg) console.error(sourceMsg)
+  boot.warnings.forEach((warning) => {
+    console.error(`${YELLOW}Warning:${RESET} ${warning}`)
+  })
+}
+
+const runEnvExport = (options: ExportOptions): void => {
+  resolveForEmit(options).fold(
     (err) => {
       console.error(formatError(err))
       process.exit(2)
     },
     (boot) => {
-      const sourceMsg = formatConfigSource(boot.configPath, boot.configSource)
-      if (sourceMsg) console.error(sourceMsg)
+      emitWarnings(boot)
+      // Emit under the namespaced wire name so `eval "$(envpkt env export)"` sets the
+      // variable the consumer actually reads.
+      collectEmitEntries(boot).forEach(({ name, value }) => {
+        console.log(`export ${name}='${shellEscape(value)}'`)
+      })
+    },
+  )
+}
 
-      boot.warnings.forEach((warning) => {
-        console.error(`${YELLOW}Warning:${RESET} ${warning}`)
+const runEnvGithub = (options: GithubOptions): void => {
+  resolveForEmit(options).fold(
+    (err) => {
+      console.error(formatError(err))
+      process.exit(2)
+    },
+    (boot) => {
+      emitWarnings(boot)
+
+      const entries = collectEmitEntries(boot)
+
+      // Mask every secret value first so GitHub redacts it everywhere in the job log.
+      // Env defaults are non-secret by design and are not masked.
+      entries.filter((e) => e.secret).forEach((e) => console.log(`::add-mask::${e.value}`))
+
+      // Build $GITHUB_ENV assignments using the heredoc form (safe for multiline / special chars).
+      const lines = entries.map(({ name, value }) => {
+        const delim = `__ENVPKT_${randomBytes(9).toString("hex")}__`
+        return `${name}<<${delim}\n${value}\n${delim}`
       })
 
-      // Emit under the namespaced wire name (boot.envNames), not the logical key,
-      // so `eval "$(envpkt env export)"` sets the variable the consumer actually reads.
-      const wireName = (key: string): string => boot.envNames[key] ?? key
-
-      Object.entries(boot.envDefaults).forEach(([key, value]) => {
-        console.log(`export ${wireName(key)}='${shellEscape(value)}'`)
-      })
-
-      // Emit env entries that boot skipped (already in process.env).
-      // Alias entries have no value of their own; fall back to reading the
-      // current process.env value (which is what they would have copied).
-      if (boot.overridden.length > 0) {
-        loadConfig(boot.configPath).fold(
-          () => {},
-          (config) => {
-            const envEntries = config.env ?? {}
-            boot.overridden.forEach((key) => {
-              if (!(key in envEntries)) return
-              const entry = envEntries[key]!
-              const name = wireName(key)
-              const value = entry.value ?? process.env[name] ?? ""
-              console.log(`export ${name}='${shellEscape(value)}'`)
-            })
-          },
+      const githubEnv = process.env["GITHUB_ENV"]
+      if (githubEnv) {
+        appendFileSync(githubEnv, lines.length > 0 ? `${lines.join("\n")}\n` : "")
+      } else {
+        console.error(
+          `${YELLOW}Warning:${RESET} GITHUB_ENV not set — printing assignments to stdout (not a GitHub Actions runner)`,
         )
+        lines.forEach((l) => console.log(l))
       }
 
-      Object.entries(boot.secrets).forEach(([key, value]) => {
-        console.log(`export ${wireName(key)}='${shellEscape(value)}'`)
-      })
+      if (options.strict) {
+        process.exit(exitCodeForAudit(boot.audit))
+      }
     },
   )
 }
@@ -599,6 +671,18 @@ export const registerEnvCommands = (program: Command): void => {
     .option("--skip-audit", "Skip the pre-flight audit")
     .action((options: ExportOptions) => {
       runEnvExport(options)
+    })
+
+  env
+    .command("github")
+    .description(
+      "Inject resolved secrets into $GITHUB_ENV for GitHub Actions, masking secret values in the log (::add-mask::)",
+    )
+    .option("-c, --config <path>", "Path to envpkt.toml")
+    .option("--profile <profile>", "fnox profile to use")
+    .option("--strict", "Exit non-zero if the pre-flight audit is not healthy")
+    .action((options: GithubOptions) => {
+      runEnvGithub(options)
     })
 
   env

--- a/src/core/boot.ts
+++ b/src/core/boot.ts
@@ -1,5 +1,6 @@
-import { existsSync } from "node:fs"
-import { dirname, resolve } from "node:path"
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
 
 import { type Either, Left, Option, Right } from "functype"
 // Import from the /direct subpath, not the barrel — the barrel eagerly loads
@@ -14,7 +15,7 @@ import { formatAliasError, validateAliases } from "./alias.js"
 import { computeAudit } from "./audit.js"
 import { resolveConfig } from "./catalog.js"
 import { expandPath, loadConfig, resolveConfigPath } from "./config.js"
-import { resolveKeyPath } from "./keygen.js"
+import { resolveInlineKey, resolveKeyPath } from "./keygen.js"
 import { isShellSafeSeparator, makeEnvNamer } from "./namespace.js"
 import { unsealSecrets } from "./seal.js"
 import type { AuditResult, BootError, BootOptions, BootResult, ConfigSource, EnvpktConfig } from "./types.js"
@@ -56,6 +57,46 @@ const resolveIdentityFilePath = (
   if (!useDefaultFallback) return Option<string>(undefined)
   const defaultPath = resolveKeyPath()
   return existsSync(defaultPath) ? Option(defaultPath) : Option<string>(undefined)
+}
+
+/** An age identity to unseal with, plus a cleanup hook (no-op for real files). */
+type IdentitySource = { readonly path: string; readonly dispose: () => void }
+
+const noop = (): void => {}
+
+/** Write an inline age key to a private temp file so the `age` CLI (file-based) can use it. */
+const materializeInlineKey = (key: string): IdentitySource => {
+  const dir = mkdtempSync(join(tmpdir(), "envpkt-age-"))
+  const keyPath = join(dir, "age-key.txt")
+  writeFileSync(keyPath, key.endsWith("\n") ? key : `${key}\n`)
+  chmodSync(keyPath, 0o600)
+  return { path: keyPath, dispose: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+/**
+ * Resolve an age identity for unsealing sealed packets. Precedence:
+ *   config.identity.key_file > ENVPKT_AGE_KEY_FILE > ENVPKT_AGE_KEY (inline) > ~/.envpkt/age-key.txt
+ * The inline key (CI secret) ranks above the homedir default so an explicit
+ * env var beats a stray local key. Inline keys are written to a 0600 temp file
+ * the caller must dispose().
+ */
+const resolveSealIdentity = (config: EnvpktConfig, configDir: string): Option<IdentitySource> => {
+  if (config.identity?.key_file) {
+    return Option<IdentitySource>({ path: resolve(configDir, expandPath(config.identity.key_file)), dispose: noop })
+  }
+  const envFile = process.env["ENVPKT_AGE_KEY_FILE"]
+  if (envFile && existsSync(envFile)) {
+    return Option<IdentitySource>({ path: envFile, dispose: noop })
+  }
+  const inlineKey = resolveInlineKey().orUndefined()
+  if (inlineKey) {
+    return Option<IdentitySource>(materializeInlineKey(inlineKey))
+  }
+  const defaultPath = join(homedir(), ".envpkt", "age-key.txt")
+  if (existsSync(defaultPath)) {
+    return Option<IdentitySource>({ path: defaultPath, dispose: noop })
+  }
+  return Option<IdentitySource>(undefined)
 }
 
 const resolveIdentityKey = (config: EnvpktConfig, configDir: string): IdentityKeyResult => {
@@ -236,32 +277,36 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
 
           // Phase 1: try sealed values (encrypted_value in meta) — non-alias only
           const sealedKeys = new Set<string>()
-          const identityFilePath = resolveIdentityFilePath(config, configDir, true)
 
           if (hasSealedValues) {
-            identityFilePath.fold(
+            resolveSealIdentity(config, configDir).fold(
               () => {
                 log.warn("phase.sealed.no_identity_file", {
                   sealed_keys: nonAliasMetaKeys.filter((k) => !!nonAliasSecretEntries[k]?.encrypted_value).length,
                 })
                 warnings.push("Sealed values found but no identity file available for decryption")
               },
-              (idPath) => {
-                unsealSecrets(nonAliasSecretEntries, idPath).fold(
-                  (err) => {
-                    log.warn("phase.sealed.decrypt_failed", { message: err.message })
-                    warnings.push(`Sealed value decryption failed: ${err.message}`)
-                  },
-                  (unsealed) => {
-                    const unsealedEntries = Object.entries(unsealed)
-                    Object.assign(secrets, unsealed)
-                    injected.push(...unsealedEntries.map(([key]) => key))
-                    unsealedEntries.forEach(([key]) => {
-                      sealedKeys.add(key)
-                      log.debug("phase.sealed.resolved", { key })
-                    })
-                  },
-                )
+              ({ path: idPath, dispose }) => {
+                // eslint-disable-next-line functype/prefer-either -- try/finally is resource cleanup (temp key file), not error handling
+                try {
+                  unsealSecrets(nonAliasSecretEntries, idPath).fold(
+                    (err) => {
+                      log.warn("phase.sealed.decrypt_failed", { message: err.message })
+                      warnings.push(`Sealed value decryption failed: ${err.message}`)
+                    },
+                    (unsealed) => {
+                      const unsealedEntries = Object.entries(unsealed)
+                      Object.assign(secrets, unsealed)
+                      injected.push(...unsealedEntries.map(([key]) => key))
+                      unsealedEntries.forEach(([key]) => {
+                        sealedKeys.add(key)
+                        log.debug("phase.sealed.resolved", { key })
+                      })
+                    },
+                  )
+                } finally {
+                  dispose()
+                }
               },
             )
           }

--- a/test/cli/env.spec.ts
+++ b/test/cli/env.spec.ts
@@ -294,6 +294,68 @@ describe("envpkt env export", () => {
   })
 })
 
+describe("envpkt env github", () => {
+  it("writes env defaults to $GITHUB_ENV under the wire name, unmasked", () => {
+    const toml = `version = 1\n\n[namespace]\nprefix = "CIV"\n\n[env.LOG_LEVEL]\nvalue = "info"\n`
+    writeFileSync(join(tmpDir, "envpkt.toml"), toml)
+    const githubEnv = join(tmpDir, "github_env")
+    writeFileSync(githubEnv, "")
+
+    const result = run(["env", "github"], { cwd: tmpDir, env: { GITHUB_ENV: githubEnv } })
+
+    expect(result.status).toBe(0)
+    const written = readFileSync(githubEnv, "utf-8")
+    expect(written).toMatch(/CIV__LOG_LEVEL<<__ENVPKT_[0-9a-f]+__\ninfo\n__ENVPKT_[0-9a-f]+__/)
+    // env defaults are non-secret — never masked
+    expect(result.stdout).not.toContain("::add-mask::info")
+  })
+
+  it("masks sealed secret values and writes them to $GITHUB_ENV", { skip: !ageInstalled }, () => {
+    const keygenOutput = execFileSync("age-keygen", [], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" })
+    const recipient = keygenOutput
+      .split("\n")
+      .find((l) => l.startsWith("# public key:"))!
+      .replace("# public key: ", "")
+      .trim()
+    const secretKey = keygenOutput
+      .split("\n")
+      .find((l) => l.startsWith("AGE-SECRET-KEY-"))!
+      .trim()
+    const encrypted = execFileSync("age", ["-r", recipient, "-a"], {
+      input: "sk-ci-secret-value",
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+
+    const toml = `version = 1\n\n[namespace]\nprefix = "CIV"\n\n[identity]\nname = "ci"\nrecipient = "${recipient}"\n\n[secret.MY_SECRET]\nservice = "test"\nencrypted_value = """\n${encrypted}"""\n`
+    writeFileSync(join(tmpDir, "envpkt.toml"), toml)
+    const githubEnv = join(tmpDir, "github_env")
+    writeFileSync(githubEnv, "")
+
+    const result = run(["env", "github"], {
+      cwd: tmpDir,
+      env: { GITHUB_ENV: githubEnv, ENVPKT_AGE_KEY: secretKey },
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("::add-mask::sk-ci-secret-value")
+    const written = readFileSync(githubEnv, "utf-8")
+    expect(written).toContain("CIV__MY_SECRET<<")
+    expect(written).toContain("sk-ci-secret-value")
+  })
+
+  it("exits non-zero under --strict when a secret is expired", () => {
+    const toml = `version = 1\n\n[secret.OLD]\nservice = "x"\ncreated = "2020-01-01"\nexpires = "2021-01-01"\n`
+    writeFileSync(join(tmpDir, "envpkt.toml"), toml)
+    const githubEnv = join(tmpDir, "github_env")
+    writeFileSync(githubEnv, "")
+
+    const result = run(["env", "github", "--strict"], { cwd: tmpDir, env: { GITHUB_ENV: githubEnv } })
+
+    expect(result.status).toBe(2)
+  })
+})
+
 describe("envpkt audit --format minimal", () => {
   it("outputs single-line status for healthy audit", () => {
     const created = new Date(Date.now() - 30 * 86_400_000).toISOString().slice(0, 10)

--- a/test/core/boot.spec.ts
+++ b/test/core/boot.spec.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process"
 import { describe, expect, it, beforeEach, afterEach } from "vitest"
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs"
+import { mkdtempSync, readdirSync, writeFileSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -344,6 +344,67 @@ describe("boot with sealed values", () => {
     )
 
     delete process.env["SEALED_KEY"]
+  })
+
+  it.skipIf(!ageInstalled)("decrypts sealed values from an inline ENVPKT_AGE_KEY with no key_file", () => {
+    const keygenOutput = execFileSync("age-keygen", [], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" })
+    const recipient = keygenOutput
+      .split("\n")
+      .find((l) => l.startsWith("# public key:"))!
+      .replace("# public key: ", "")
+      .trim()
+    const secretKey = keygenOutput
+      .split("\n")
+      .find((l) => l.startsWith("AGE-SECRET-KEY-"))!
+      .trim()
+
+    const ciphertext = ageEncrypt("inline-ci-value", recipient).fold(
+      () => "",
+      (v) => v,
+    )
+
+    // No key_file — only an inline key, as in CI
+    const configPath = writeConfig(
+      [
+        `version = 1`,
+        `[identity]`,
+        `name = "ci"`,
+        `recipient = "${recipient}"`,
+        `[secret.CI_KEY]`,
+        `service = "test"`,
+        `encrypted_value = """`,
+        ciphertext,
+        `"""`,
+      ].join("\n"),
+    )
+
+    const origKey = process.env["ENVPKT_AGE_KEY"]
+    const origFile = process.env["ENVPKT_AGE_KEY_FILE"]
+    delete process.env["ENVPKT_AGE_KEY_FILE"]
+    process.env["ENVPKT_AGE_KEY"] = secretKey
+    delete process.env["CI_KEY"]
+
+    const tmpBefore = readdirSync(tmpdir()).filter((d) => d.startsWith("envpkt-age-")).length
+
+    try {
+      const result = bootSafe({ configPath, inject: false })
+      result.fold(
+        (err) => expect.unreachable(`Expected Right, got ${err._tag}`),
+        (boot) => {
+          expect(boot.secrets["CI_KEY"]).toBe("inline-ci-value")
+          expect(boot.injected).toContain("CI_KEY")
+        },
+      )
+      // temp identity file must be cleaned up
+      const tmpAfter = readdirSync(tmpdir()).filter((d) => d.startsWith("envpkt-age-")).length
+      expect(tmpAfter).toBe(tmpBefore)
+    } finally {
+      if (origKey === undefined) delete process.env["ENVPKT_AGE_KEY"]
+      else process.env["ENVPKT_AGE_KEY"] = origKey
+      if (origFile === undefined) delete process.env["ENVPKT_AGE_KEY_FILE"]
+      else process.env["ENVPKT_AGE_KEY_FILE"] = origFile
+      delete process.env["CI_KEY"]
+    }
   })
 
   it.skipIf(!ageInstalled)("decrypts sealed values using default key path when key_file is unset", () => {


### PR DESCRIPTION
## Summary

Lets a CI build resolve the credentials in `envpkt.toml` into the job environment — **with secret values masked in the log**. First substantive package change since the namespace feature (0.11.6); 0.11.7–0.11.9 shipped no functional change.

Three layers:

1. **`envpkt env github`** (engine) — resolves credentials and appends them to `$GITHUB_ENV` under their namespaced [wire names](https://envpkt.dev/reference/toml-schema/#namespace) so later steps in the job inherit them. Each **secret** value is registered with `::add-mask::` (redacted everywhere in the log); env defaults are written but not masked. `--strict` gates the build on the pre-flight audit. Shares resolution (`resolveForEmit`/`collectEmitEntries`) with `env export`.
2. **Composite Action** (`action.yml`) — `uses: jordanburke/envpkt@v1` with inputs `config`/`version`/`strict`/`profile`, wrapping `env github`.
3. **Inline age key in `boot()`** — `ENVPKT_AGE_KEY` (a CI secret) is now honored to decrypt sealed packets with **no key file**: it's materialized to a `0600` temp file and removed after use. Precedence: `identity.key_file` → `ENVPKT_AGE_KEY_FILE` → `ENVPKT_AGE_KEY` → `~/.envpkt/age-key.txt`.

```yaml
- uses: jordanburke/envpkt@v1
  with: { config: ./envpkt.toml, strict: "true" }
  env: { ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }} }
- run: ./deploy.sh   # sees CIV__API_KEY etc.; secret values redacted in the log
```

## Test plan

- `pnpm validate` → exit 0 (format, lint **0 warnings**, typecheck, **518 tests**, schema, build)
- `pnpm docs:build` → 41 pages, clean (new integration + CLI pages)
- New tests: `env github` (masks secrets, writes `$GITHUB_ENV` heredoc under wire name, env defaults unmasked, `--strict` exit code) and `boot()` inline-key unseal (resolves from `ENVPKT_AGE_KEY`, temp file cleaned up).
- Manual smoke confirmed end-to-end: sealed packet + inline key → `::add-mask::` on stdout + heredoc assignments in `$GITHUB_ENV`.

## Manually verified (not in CI)

The composite **`action.yml`** can't be exercised by in-repo unit tests. The engine it calls is fully tested; the Action itself is thin orchestration (`npx envpkt env github`). Worth a `workflow_dispatch` smoke once merged.

## Release

This changes `dist`/`lib` — a real publish. Intended as a **minor** bump → `0.12.0` (CHANGELOG entry already in this PR; also backfills the missing 0.11.9 line). Changelog ships in the feature commit, not a follow-up release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)