### PR TITLE
docs/ci: pin Action ref to a released tag + document it; gate publish to semver tags

### DIFF
--- a/.claude/skills/envpkt/SKILL.md
+++ b/.claude/skills/envpkt/SKILL.md
@@ -284,7 +284,8 @@ See `references/quick-reference.md` for a compact cheat sheet.
 CI: emits `::add-mask::` for each secret (redacts it from the log) and appends heredoc
 assignments to `$GITHUB_ENV` (using namespaced wire names) so later job steps inherit them;
 env defaults are written but not masked. `--strict` exits with the audit code (1/2) after
-injecting. There is also a composite Action: `uses: jordanburke/envpkt@v1`.
+injecting. There is also a composite Action: `uses: jordanburke/envpkt@v0.12.0` (pin to a
+released tag; no moving major tag is published yet).
 
 **CI age-key contract**: supply the age private key inline via the `ENVPKT_AGE_KEY` env var
 (e.g. a GitHub secret) — `boot()` materializes it to a `0600` temp file to decrypt sealed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,9 @@ name: Publish to NPM
 on:
   push:
     tags:
-      - "v*"
+      # Full semver tags only (e.g. v0.12.0). Moving/major tags like `v1` or `v0`
+      # (used to reference the GitHub Action) intentionally do NOT trigger a publish.
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   later steps in the job inherit them. Secret values are masked in the log via
   `::add-mask::`; env defaults are written but not masked. `--strict` gates the build on the
   pre-flight audit.
-- **Composite GitHub Action** (`action.yml`) — `uses: jordanburke/envpkt@v1` with inputs
+- **Composite GitHub Action** (`action.yml`) — `uses: jordanburke/envpkt@v0.12.0` with inputs
   `config` / `version` / `strict` / `profile`, wrapping `env github`.
 - **Inline age key for CI.** `boot()` now honors an inline `ENVPKT_AGE_KEY` (e.g. a CI
   secret): it is materialized to a `0600` temp file to decrypt sealed packets and removed

--- a/README.md
+++ b/README.md
@@ -210,6 +210,29 @@ const result = boot() // decrypts sealed values, injects into process.env
 
 Mixed mode is supported — sealed values take priority, with fnox as fallback for keys without `encrypted_value`.
 
+## GitHub Actions
+
+A composite action resolves the credentials in `envpkt.toml` into the CI job — with secret values masked in the log — so later steps just see them as environment variables:
+
+```yaml
+- uses: actions/checkout@v5
+
+- uses: jordanburke/envpkt@v0.12.0
+  with:
+    config: ./envpkt.toml
+    strict: "true" # fail the build if a credential is expired/unhealthy
+  env:
+    ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }}
+
+- run: ./deploy.sh # sees the resolved vars; secret values redacted in the log
+```
+
+**How it works.** Commit sealed (`encrypted_value`) packets to the repo and supply the age private key as the `ENVPKT_AGE_KEY` secret. `boot()` materializes the inline key to a `0600` temp file to decrypt, then [`env github`](#envpkt-env-github) masks each secret (`::add-mask::`) and writes it to `$GITHUB_ENV`. Identity precedence: `identity.key_file` → `ENVPKT_AGE_KEY_FILE` → `ENVPKT_AGE_KEY` (inline) → `~/.envpkt/age-key.txt`.
+
+**Inputs:** `config`, `version` (npm version to run, default `latest`), `strict`, `profile`.
+
+> Pin to a released tag (e.g. `@v0.12.0`). No moving major tag (`@v1`) is published yet. Node is assumed present on the runner; add `actions/setup-node` first to pin a version.
+
 ## Fleet Management
 
 When you're running multiple agents, `envpkt fleet` scans a directory tree for `envpkt.toml` files and aggregates credential health across your entire fleet.
@@ -435,6 +458,15 @@ Add to your shell startup (e.g. `~/.zshrc` or `~/.bashrc`) for automatic secret 
 
 ```bash
 eval "$(envpkt env export 2>/dev/null)"
+```
+
+### `envpkt env github`
+
+Inject resolved secrets into a GitHub Actions job. Emits `::add-mask::` for each secret value (redacting it from the log) and appends assignments to `$GITHUB_ENV` — under their namespaced wire names — so later steps in the job inherit them. Env defaults are written but not masked. `--strict` exits non-zero if the pre-flight audit is unhealthy. This is the engine behind the [GitHub Action](#github-actions).
+
+```bash
+# Run as a step; later steps in the job see the resolved vars
+npx envpkt env github --strict
 ```
 
 ### `envpkt shell-hook`

--- a/site/src/content/docs/cli/env-github.mdx
+++ b/site/src/content/docs/cli/env-github.mdx
@@ -73,5 +73,5 @@ credentials. Without `--strict` it always exits `0`.
 
 ## See also
 
-- [GitHub Action](/integrations/github-action/) — the `uses: jordanburke/envpkt@v1` wrapper.
+- [GitHub Action](/integrations/github-action/) — the `uses: jordanburke/envpkt@v0.12.0` wrapper.
 - [`envpkt env export`](/cli/env-export/) — the shell-`eval` analog for local/non-GitHub use.

--- a/site/src/content/docs/guides/ci-cd.mdx
+++ b/site/src/content/docs/guides/ci-cd.mdx
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jordanburke/envpkt@v1
+      - uses: jordanburke/envpkt@v0.12.0
         with:
           config: ./envpkt.toml
           strict: "true"

--- a/site/src/content/docs/integrations/github-action.mdx
+++ b/site/src/content/docs/integrations/github-action.mdx
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jordanburke/envpkt@v1
+      - uses: jordanburke/envpkt@v0.12.0
         with:
           config: ./envpkt.toml
           strict: "true"
@@ -47,7 +47,7 @@ Sealed (`encrypted_value`) packets are the typical CI source: commit them to the
 repository/organization secret named `ENVPKT_AGE_KEY` on the step's `env`:
 
 ```yaml
-- uses: jordanburke/envpkt@v1
+- uses: jordanburke/envpkt@v0.12.0
   env:
     ENVPKT_AGE_KEY: ${{ secrets.ENVPKT_AGE_KEY }}
 ```


### PR DESCRIPTION
## Summary

Follow-up to #37. Fixes a broken Action reference, removes a tag-collision footgun, and documents the Action in the README.

1. **`@v1` doesn't resolve.** GitHub fetches actions by **git ref** (tag/branch/SHA), and there's no `v1` tag — only `v0.12.0`. The package is also `0.x`, so advertising `@v1` is both broken and incongruent. All docs/skill/CHANGELOG examples now use **`@v0.12.0`** (a real tag).
2. **Tag-collision footgun.** The publish workflow triggered on `tags: ["v*"]`, so creating a moving Action tag like `v1`/`v0` would have **re-fired the npm publish** (and failed on a duplicate version). Trigger is now `v[0-9]+.[0-9]+.[0-9]+` — full semver only; bare major/minor tags are free for the Action.
3. **README docs.** The README had no CI/Action section and didn't list `env github`. Added an `envpkt env github` CLI subsection and a **GitHub Actions** section (usage, the `ENVPKT_AGE_KEY` sealed-packet contract, inputs).

## How GitHub resolves the Action (for context)

`uses: owner/repo@ref` → GitHub checks out the repo at `ref` and reads `action.yml` at the **repo root** (where ours lives — correct for a single-action repo; subfolders are only for multi-action repos and lose Marketplace eligibility). This is entirely separate from npm — `action.yml` is not in the npm `files` list and doesn't need to be.

## Not done (deliberately)

- **No moving `v0`/`v1` tag yet.** Per the plan, hold until the Action is smoke-tested via `workflow_dispatch`. Once it is, the trigger fix here makes a moving tag safe to publish, and docs can switch to `@v0`.
- **No release.** Docs + CI config only — nothing in `dist`/`lib` changes.

## Test plan

- `pnpm validate` → exit 0 (518 tests, lint clean)
- `pnpm docs:build` → 41 pages, clean
- The tightened trigger is verified by inspection: `v[0-9]+.[0-9]+.[0-9]+` matches `v0.12.0` but not `v1`/`v0` (GitHub tag-filter glob: `[0-9]` range + `+` one-or-more + literal `.`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)