### PR TITLE
ci: add workflow_dispatch smoke test for the composite action

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,73 @@
+name: Action Smoke Test
+
+# Manually-triggered end-to-end check of the composite action (action.yml).
+# Fully self-contained: generates a throwaway age keypair, seals a test value,
+# runs the LOCAL action (uses: ./), and asserts the secret was decrypted, masked,
+# and propagated to a later step via $GITHUB_ENV. No repository secrets required.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "envpkt version the action should run via npx"
+        required: false
+        default: "latest"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Sealed packets are decrypted with the `age` CLI, which is not preinstalled.
+      - name: Install age
+        run: sudo apt-get update && sudo apt-get install -y age
+
+      - name: Create an ephemeral sealed config
+        shell: bash
+        run: |
+          set -euo pipefail
+          keys="$(age-keygen 2>/dev/null)"
+          recipient="$(echo "$keys" | sed -n 's/# public key: //p')"
+          secret="$(echo "$keys" | grep '^AGE-SECRET-KEY-')"
+          ciphertext="$(printf 'smoke-value' | age -r "$recipient" -a)"
+
+          cfg="$RUNNER_TEMP/envpkt.toml"
+          {
+            echo 'version = 1'
+            echo '[namespace]'
+            echo 'prefix = "CIV"'
+            echo '[secret.SMOKE_KEY]'
+            echo 'service = "smoke"'
+            printf 'encrypted_value = """\n%s"""\n' "$ciphertext"
+          } > "$cfg"
+
+          # Throwaway key — mask it and hand it to the action via the job env.
+          echo "::add-mask::$secret"
+          {
+            echo "ENVPKT_SMOKE_CONFIG=$cfg"
+            echo "ENVPKT_AGE_KEY=$secret"
+          } >> "$GITHUB_ENV"
+
+      - name: Run the envpkt action
+        uses: ./
+        with:
+          config: ${{ env.ENVPKT_SMOKE_CONFIG }}
+          version: ${{ inputs.version }}
+          strict: "true"
+        env:
+          ENVPKT_AGE_KEY: ${{ env.ENVPKT_AGE_KEY }}
+
+      - name: Verify injection into $GITHUB_ENV
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${CIV__SMOKE_KEY:-}" != "smoke-value" ]; then
+            echo "FAIL: CIV__SMOKE_KEY was not injected (got: '${CIV__SMOKE_KEY:-<unset>}')"
+            exit 1
+          fi
+          # The plain/logical name must NOT be set — only the namespaced wire name.
+          if [ -n "${SMOKE_KEY:-}" ]; then
+            echo "FAIL: unexpected logical name SMOKE_KEY is set"
+            exit 1
+          fi
+          echo "OK: sealed secret resolved (inline ENVPKT_AGE_KEY), masked, and injected as CIV__SMOKE_KEY"


### PR DESCRIPTION
## Summary

Adds a manually-triggered (`workflow_dispatch`) end-to-end smoke test for the composite `action.yml` — the one piece #37 couldn't cover with in-repo unit tests.

It's **fully self-contained** (no repository secrets):

1. Installs `age` on the runner.
2. Generates a throwaway age keypair and seals a test value (`smoke-value`) into an ephemeral `envpkt.toml` with a `[namespace]`.
3. Runs the **local** action (`uses: ./`) with the inline key (`ENVPKT_AGE_KEY`) and `strict: "true"`.
4. Asserts a later step sees `CIV__SMOKE_KEY=smoke-value` (resolution + inline-key decryption + `$GITHUB_ENV` propagation + namespace wire name all working), and that the logical name `SMOKE_KEY` is **not** set.

## How to run

After merge (workflow_dispatch is only triggerable from the default branch):

```bash
gh workflow run "Action Smoke Test"
```

## Finding worth acting on

Sealed packets are decrypted with the **`age` CLI**, which isn't preinstalled on GitHub runners — the smoke installs it. This means **consumers using sealed packets in CI also need `age` on the runner**, and the action does not install it. That requirement isn't currently called out in the Action docs. Options for a follow-up:
- Document "install `age` first" in the GitHub Action docs (cheapest), or
- Have the action optionally install `age` (heavier/opinionated, platform-specific).

I left the action unchanged here; happy to patch the docs (or the action) in a follow-up — flagging so it's a deliberate decision.

## Notes

- CI-only (new workflow file); no `dist`/`lib` change, no release.
- Masking is exercised (the action emits `::add-mask::`) though not asserted — it's a log-rendering behavior; visible as `***` in the run log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)