### PR TITLE
ci/docs: auto-run the action smoke + document the age-on-runner requirement

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -11,6 +11,19 @@ on:
         description: "envpkt version the action should run via npx"
         required: false
         default: "latest"
+  # Gate changes to the action itself / this workflow.
+  pull_request:
+    paths:
+      - "action.yml"
+      - ".github/workflows/action-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "action.yml"
+      - ".github/workflows/action-smoke.yml"
+  # Catch drift in the published CLI that the action runs (no commit required).
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC
 
 jobs:
   smoke:
@@ -52,7 +65,7 @@ jobs:
         uses: ./
         with:
           config: ${{ env.ENVPKT_SMOKE_CONFIG }}
-          version: ${{ inputs.version }}
+          version: ${{ inputs.version || 'latest' }}
           strict: "true"
         env:
           ENVPKT_AGE_KEY: ${{ env.ENVPKT_AGE_KEY }}

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ A composite action resolves the credentials in `envpkt.toml` into the CI job —
 ```yaml
 - uses: actions/checkout@v5
 
+# Sealed packets are decrypted with the `age` CLI (not preinstalled on runners).
+- run: sudo apt-get update && sudo apt-get install -y age
+
 - uses: jordanburke/envpkt@v0.12.0
   with:
     config: ./envpkt.toml
@@ -231,7 +234,7 @@ A composite action resolves the credentials in `envpkt.toml` into the CI job —
 
 **Inputs:** `config`, `version` (npm version to run, default `latest`), `strict`, `profile`.
 
-> Pin to a released tag (e.g. `@v0.12.0`). No moving major tag (`@v1`) is published yet. Node is assumed present on the runner; add `actions/setup-node` first to pin a version.
+> Decrypting sealed packets requires the [`age`](https://github.com/FiloSottile/age) CLI on the runner (install it first, as above) — not needed if you only inject plaintext `[env.*]` defaults or resolve via fnox. Pin to a released tag (e.g. `@v0.12.0`); no moving major tag (`@v1`) is published yet. Node is assumed present; add `actions/setup-node` first to pin a version.
 
 ## Fleet Management
 

--- a/site/src/content/docs/integrations/github-action.mdx
+++ b/site/src/content/docs/integrations/github-action.mdx
@@ -59,6 +59,17 @@ afterwards — no key file needs to live in the repo or runner. Identity precede
 identity.key_file  >  ENVPKT_AGE_KEY_FILE  >  ENVPKT_AGE_KEY (inline)  >  ~/.envpkt/age-key.txt
 ```
 
+:::caution[Sealed packets need the `age` CLI on the runner]
+Decrypting `encrypted_value` packets shells out to [`age`](https://github.com/FiloSottile/age),
+which is **not** preinstalled on GitHub-hosted runners. Install it before the `envpkt` step:
+
+```yaml
+- run: sudo apt-get update && sudo apt-get install -y age
+```
+
+(Not needed if you only inject plaintext `[env.*]` defaults, or resolve via fnox.)
+:::
+
 ## Masking
 
 Every secret value is registered with GitHub via `::add-mask::` **before** it is written,


### PR DESCRIPTION
## Summary

Follow-up to #39 — make the Action smoke continuous instead of manual-only, and document the `age` requirement it surfaced.

**Auto-triggers** (kept `workflow_dispatch`):
1. `pull_request` + `push` to `main`, **path-filtered** to `action.yml` and the smoke workflow — gates changes to the Action itself.
2. Weekly `schedule` (Mon 09:00 UTC) — catches drift in the **published** CLI the action runs via `npx` (no commit needed).

The action `version` input now falls back to `'latest'` on non-dispatch events (where `inputs.version` is empty), so scheduled/PR runs don't pass `envpkt@`.

**Docs:** sealed-packet decryption shells out to `age`, which isn't preinstalled on runners. Added a note + install step (`apt-get install -y age`) to the GitHub Action page and the README (not needed for plaintext `[env.*]` or fnox).

## Note on scope (why not run on every PR)

The action runs `npx envpkt@latest`, so the smoke validates **action wiring against the published CLI** — it can't see unpublished PR code. Running it on every PR would mostly burn an `apt-get` minute on unrelated changes. The CLI's own behavior is already covered by the vitest e2e tests in Node.js CI on every push/PR; this smoke specifically guards the Action wrapper + published-CLI compatibility, which is why it's path-filtered + scheduled rather than always-on.

## Self-validating

This PR touches `action-smoke.yml`, which matches the new `pull_request` path filter — so the **Action Smoke Test** runs as a check here, exercising the new triggers end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)