### PR TITLE
fix(secret): add --unset to clear optional fields + validate --dry-run (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`secret edit --unset <field>`** removes an optional metadata field (repeatable). Field
+  names are the canonical TOML keys (e.g. `rate_limit`). You can unset any field you can set
+  with a flag; unknown field names are rejected rather than silently ignored. Previously the
+  only way to drop a field was hand-editing the TOML, since `--field ""` failed schema
+  validation. ([#31](https://github.com/jordanburke/envpkt/issues/31))
+
+### Fixed
+
+- **`--dry-run` now runs the same schema validation as the real write** across `secret`
+  subcommands. Previously a dry-run could preview a change (e.g. `expires = ""`) that the
+  actual write would then reject, so the preview no longer misrepresents what will be
+  accepted. ([#31](https://github.com/jordanburke/envpkt/issues/31))
+
 ## [0.12.0] - 2026-06-07
 
 ### Added

--- a/site/src/content/docs/cli/secret.mdx
+++ b/site/src/content/docs/cli/secret.mdx
@@ -55,6 +55,20 @@ envpkt secret edit STRIPE_API_KEY --expires 2026-12-31 --rotates 60d
 envpkt secret edit STRIPE_API_KEY --no-required
 ```
 
+### Removing optional fields with `--unset`
+
+Setting a field is reversible: `--unset <field>` removes an optional metadata field entirely. It's repeatable, and the field names are the TOML keys you see in the file (e.g. `rate_limit`, not `rate-limit`). You can unset any field you can set with a flag — structural/managed fields (`created`, `encrypted_value`, `from_key`) are owned by `seal`/`rotate`/`alias` and are not unsettable here. An unknown field name is rejected rather than silently ignored.
+
+```bash
+# Drop a single field
+envpkt secret edit STRIPE_API_KEY --unset expires
+
+# Drop several at once
+envpkt secret edit STRIPE_API_KEY --unset expires --unset rate_limit
+```
+
+`--dry-run` runs the same schema validation as the real write, so a preview never shows a result the write would reject.
+
 ## `secret rm`
 
 Remove a secret entry from the file.

--- a/src/cli/commands/secret.ts
+++ b/src/cli/commands/secret.ts
@@ -8,7 +8,7 @@ import { loadConfig, resolveConfigPath } from "../../core/config.js"
 import { ageEncrypt } from "../../core/seal.js"
 import { appendSection, removeSection, renameSection, updateSectionFields } from "../../core/toml-edit.js"
 import { BOLD, CYAN, DIM, formatConfigSource, formatError, GREEN, RED, RESET, YELLOW } from "../output.js"
-import { writeIfValid } from "../write-gate.js"
+import { previewIfValid, writeIfValid } from "../write-gate.js"
 import { applySealedToml } from "./seal.js"
 
 type AddOptions = {
@@ -42,8 +42,31 @@ type EditOptions = {
   readonly required?: boolean
   readonly rotationUrl?: string
   readonly tags?: string
+  readonly unset?: ReadonlyArray<string>
   readonly dryRun?: boolean
 }
+
+/**
+ * Fields removable via `--unset` — exactly the metadata fields settable via a flag.
+ * Mental model: you can unset any field you can set. Structural/managed fields
+ * (`created`, `last_rotated_at`, `encrypted_value`, `from_key`, `namespace`) are
+ * intentionally excluded — they're owned by `seal`/`rotate`/`alias`, not `edit`.
+ * Field names are the canonical TOML keys (e.g. `rate_limit`, not `rate-limit`).
+ */
+const UNSETTABLE_FIELDS: ReadonlyArray<string> = [
+  "service",
+  "purpose",
+  "comment",
+  "expires",
+  "rotates",
+  "rate_limit",
+  "model_hint",
+  "source",
+  "rotation_url",
+  "required",
+  "capabilities",
+  "tags",
+]
 
 type RmOptions = {
   readonly config?: string
@@ -128,6 +151,11 @@ const buildFieldUpdates = (options: EditOptions): Record<string, string | null> 
     })
     updates["tags"] = `{ ${pairs.join(", ")} }`
   }
+  // Removals last so `--unset X` wins if X was also set via a value flag.
+  // A null value tells updateSectionFields to drop the field entirely.
+  options.unset?.forEach((field) => {
+    updates[field] = null
+  })
   return updates
 }
 
@@ -178,15 +206,15 @@ const runSecretAdd = (name: string, options: AddOptions): void => {
           }
 
           const block = buildSecretBlock(name, options)
+          const raw = readFileSync(configPath, "utf-8")
+          const updated = appendSection(raw, block)
 
           if (options.dryRun) {
-            console.log(`${DIM}# Preview (--dry-run):${RESET}\n`)
-            console.log(block)
+            // Validate the full resulting config, but preview just the new block.
+            previewIfValid(updated, block)
             return
           }
 
-          const raw = readFileSync(configPath, "utf-8")
-          const updated = appendSection(raw, block)
           writeIfValid(
             configPath,
             updated,
@@ -201,6 +229,13 @@ const runSecretAdd = (name: string, options: AddOptions): void => {
 const runSecretEdit = (name: string, options: EditOptions): void => {
   if (options.expires && !DATE_RE.test(options.expires)) {
     console.error(`${RED}Error:${RESET} Invalid date format for --expires: "${options.expires}" (expected YYYY-MM-DD)`)
+    process.exit(1)
+  }
+
+  const unknownUnset = (options.unset ?? []).filter((f) => !UNSETTABLE_FIELDS.includes(f))
+  if (unknownUnset.length > 0) {
+    console.error(`${RED}Error:${RESET} Cannot --unset unknown field(s): ${unknownUnset.join(", ")}`)
+    console.error(`${DIM}Unsettable fields: ${UNSETTABLE_FIELDS.join(", ")}${RESET}`)
     process.exit(1)
   }
 
@@ -231,8 +266,7 @@ const runSecretEdit = (name: string, options: EditOptions): void => {
           },
           (updated) => {
             if (options.dryRun) {
-              console.log(`${DIM}# Preview (--dry-run):${RESET}\n`)
-              console.log(updated)
+              previewIfValid(updated)
               return
             }
             writeIfValid(
@@ -257,8 +291,7 @@ const runSecretRm = (name: string, options: RmOptions): void => {
       },
       (updated) => {
         if (options.dryRun) {
-          console.log(`${DIM}# Preview (--dry-run):${RESET}\n`)
-          console.log(updated)
+          previewIfValid(updated)
           return
         }
         writeIfValid(
@@ -281,8 +314,7 @@ const runSecretRename = (oldName: string, newName: string, options: RenameOption
       },
       (updated) => {
         if (options.dryRun) {
-          console.log(`${DIM}# Preview (--dry-run):${RESET}\n`)
-          console.log(updated)
+          previewIfValid(updated)
           return
         }
         writeIfValid(
@@ -488,8 +520,7 @@ const runSecretRotate = async (name: string, options: RotateOptions): Promise<vo
       },
       (result) => {
         if (options.dryRun) {
-          console.log(`${DIM}# Preview (--dry-run):${RESET}\n`)
-          console.log(result)
+          previewIfValid(result)
           return
         }
         writeIfValid(
@@ -535,8 +566,7 @@ const runSecretRotate = async (name: string, options: RotateOptions): Promise<vo
     },
     (result) => {
       if (options.dryRun) {
-        console.log(`${DIM}# Preview (--dry-run):${RESET}\n`)
-        console.log(result)
+        previewIfValid(result)
         return
       }
       writeIfValid(
@@ -577,6 +607,8 @@ export const registerSecretCommands = (program: Command): void => {
     runSecretAdd(name, options)
   })
 
+  const collect = (value: string, previous: ReadonlyArray<string>): ReadonlyArray<string> => [...previous, value]
+
   const editCmd = secret
     .command("edit")
     .description("Update metadata fields on an existing secret")
@@ -584,6 +616,12 @@ export const registerSecretCommands = (program: Command): void => {
     .option("-c, --config <path>", "Path to envpkt.toml")
     .option("--required", "Mark this secret as required")
     .option("--no-required", "Mark this secret as not required")
+    .option(
+      "--unset <field>",
+      "Remove an optional field (repeatable). Field names match TOML keys, e.g. expires, rate_limit",
+      collect,
+      [],
+    )
     .option("--dry-run", "Preview the changes without writing")
 
   addSecretFlags(editCmd).action((name: string, options: EditOptions) => {

--- a/src/cli/write-gate.ts
+++ b/src/cli/write-gate.ts
@@ -33,3 +33,18 @@ export const writeIfValid = (configPath: string, updated: string, successMsg: st
   writeFileSync(configPath, updated, "utf-8")
   console.log(successMsg)
 }
+
+/**
+ * Validate then preview (no write) — the `--dry-run` counterpart of `writeIfValid`.
+ * Runs the same structural validation the real write would, so a dry-run can never
+ * show a result that the actual write would reject. On invalid output it prints the
+ * same error and exits 1, exactly as the write path does.
+ *
+ * `display` lets callers preview a focused slice (e.g. just the new block for `add`)
+ * while still validating the full resulting config.
+ */
+export const previewIfValid = (updated: string, display?: string): void => {
+  validateOrExit(updated)
+  console.log(`${DIM}# Preview (--dry-run):${RESET}\n`)
+  console.log(display ?? updated)
+}

--- a/test/cli/secret.spec.ts
+++ b/test/cli/secret.spec.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from "node:child_process"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -141,5 +143,123 @@ describe("secret rename (via renameSection)", () => {
       (err) => expect(err._tag).toBe("SectionAlreadyExists"),
       () => expect.unreachable("Should be Left"),
     )
+  })
+})
+
+// CLI-level tests for behavior that lives in the command layer (flag parsing,
+// --unset, dry-run validation) rather than in the core toml-edit functions.
+const __testDir = dirname(fileURLToPath(import.meta.url))
+const CLI_SRC = resolve(__testDir, "../..", "src/cli/index.ts")
+const TSX = resolve(__testDir, "../..", "node_modules/.bin/tsx")
+
+const runCli = (args: string[]): { stdout: string; stderr: string; status: number } => {
+  try {
+    const stdout = execFileSync(TSX, [CLI_SRC, ...args], {
+      env: { ...process.env },
+      encoding: "utf-8",
+      timeout: 15000,
+    })
+    return { stdout, stderr: "", status: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number }
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", status: e.status ?? 1 }
+  }
+}
+
+describe("secret edit --unset (CLI)", () => {
+  const tomlWithOptionals = `version = 1
+
+[secret.MY_KEY]
+service = "stripe"
+expires = "2026-12-31"
+rate_limit = "1000/min"
+`
+
+  it("removes an optional field and preserves the rest", () => {
+    writeFileSync(configPath, tomlWithOptionals)
+    const { status } = runCli(["secret", "edit", "MY_KEY", "--unset", "expires", "-c", configPath])
+    expect(status).toBe(0)
+
+    const content = readFileSync(configPath, "utf-8")
+    expect(content).not.toContain("expires")
+    expect(content).toContain('service = "stripe"')
+    expect(content).toContain('rate_limit = "1000/min"')
+  })
+
+  it("removes multiple fields when --unset is repeated", () => {
+    writeFileSync(configPath, tomlWithOptionals)
+    const { status } = runCli([
+      "secret",
+      "edit",
+      "MY_KEY",
+      "--unset",
+      "expires",
+      "--unset",
+      "rate_limit",
+      "-c",
+      configPath,
+    ])
+    expect(status).toBe(0)
+
+    const content = readFileSync(configPath, "utf-8")
+    expect(content).not.toContain("expires")
+    expect(content).not.toContain("rate_limit")
+    expect(content).toContain('service = "stripe"')
+  })
+
+  it("rejects an unknown field instead of silently doing nothing", () => {
+    writeFileSync(configPath, tomlWithOptionals)
+    const { stderr, status } = runCli(["secret", "edit", "MY_KEY", "--unset", "bogus", "-c", configPath])
+    expect(status).toBe(1)
+    expect(stderr).toContain("unknown field")
+    // File must be untouched
+    expect(readFileSync(configPath, "utf-8")).toBe(tomlWithOptionals)
+  })
+
+  it("the result still loads as a valid config after unsetting", () => {
+    writeFileSync(configPath, tomlWithOptionals)
+    runCli(["secret", "edit", "MY_KEY", "--unset", "expires", "-c", configPath])
+    loadConfig(configPath).fold(
+      (err) => expect.unreachable(`Config should be valid after unset, got: ${err._tag}`),
+      (config) => expect(config.secret!["MY_KEY"]!.expires).toBeUndefined(),
+    )
+  })
+})
+
+describe("secret edit --dry-run validation (CLI)", () => {
+  const tomlWithExpires = `version = 1
+
+[secret.MY_KEY]
+service = "stripe"
+expires = "2026-12-31"
+`
+
+  it("dry-run rejects an edit the real write would reject (no misleading preview)", () => {
+    // The secondary bug in #31: --dry-run skipped the schema validation the real
+    // write runs, so it happily previewed expires = "" which then failed on write.
+    writeFileSync(configPath, tomlWithExpires)
+    const { stderr, status } = runCli(["secret", "edit", "MY_KEY", "--expires", "", "--dry-run", "-c", configPath])
+    expect(status).toBe(1)
+    expect(stderr).toContain("invalid config")
+    // dry-run never writes
+    expect(readFileSync(configPath, "utf-8")).toBe(tomlWithExpires)
+  })
+
+  it("dry-run previews a valid edit without writing", () => {
+    writeFileSync(configPath, tomlWithExpires)
+    const { stdout, status } = runCli([
+      "secret",
+      "edit",
+      "MY_KEY",
+      "--expires",
+      "2027-01-01",
+      "--dry-run",
+      "-c",
+      configPath,
+    ])
+    expect(status).toBe(0)
+    expect(stdout).toContain("2027-01-01")
+    // file unchanged by dry-run
+    expect(readFileSync(configPath, "utf-8")).toBe(tomlWithExpires)
   })
 })


### PR DESCRIPTION
Closes #31.

## Problem

`secret edit` could *set* optional metadata fields but never *remove* one. Blanking a field was rejected by schema validation:

```
$ envpkt secret edit MY_KEY --expires ""
  Schema validation failed: /secret/MY_KEY/expires: Expected string to match 'date' format
```

So the only way to drop an optional field was hand-editing the TOML — exactly what the CLI otherwise discourages.

**Secondary bug:** `--dry-run` skipped the schema validation the real write runs, so it happily previewed `expires = ""` as if it would be written, then the actual write failed.

## Fix

- **`secret edit --unset <field>`** — repeatable, removes an optional field. Feeds `null` into the existing `updateSectionFields` removal path (the core already supported removal; only the CLI surface was missing). Field names are the canonical TOML keys (e.g. `rate_limit`). Mental model: *you can unset any field you can set with a flag* — structural/managed fields (`created`, `encrypted_value`, `from_key`) are owned by `seal`/`rotate`/`alias` and excluded. Unknown field names are rejected with the valid list, not silently ignored.
- **`--dry-run` now validates** via a new `previewIfValid` helper that shares the exact path as `writeIfValid`. Applied across the `secret` subcommands so a preview can never show a result the write would reject.

## Examples

```bash
envpkt secret edit STRIPE_API_KEY --unset expires
envpkt secret edit STRIPE_API_KEY --unset expires --unset rate_limit
```

## Notes / judgment calls

- **Scope:** the issue named `edit`, but the lying-preview defect was identical in `add`/`rm`/`rename`/`rotate`. The shared `previewIfValid` is *less* code than the duplicated dry-run blocks it replaces, so it's applied everywhere — root-cause rather than band-aid. `secret alias`'s dry-run is left alone (bespoke output, out of scope).
- **No required-field guard:** every `SecretMeta` field is `Type.Optional` (required-ness is a lifecycle/audit policy, not schema), so `--unset service` writes fine and `audit` flags it later if `require_service` is set — consistent with how `secret add` already behaves.

## Testing

- 6 new CLI-level tests (the bug lived in the command layer; the existing spec only covered the core toml-edit functions): unset single/multiple, unknown-field rejection, result still loads, dry-run rejects invalid edits, dry-run previews valid edits without writing.
- Full `pnpm validate` green: format, lint, typecheck, 524 tests, schema, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)