### PR TITLE
fix(boot): fail fast when a sealed packet's decryption key is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`boot()`/`bootSafe()` now fail fast when a sealed packet's decryption key is absent**, instead
+  of warning and injecting empty values. A package with `encrypted_value` entries and no resolvable
+  key (`identity.key_file` → `ENVPKT_AGE_KEY_FILE` → `ENVPKT_AGE_KEY` → `~/.envpkt/age-key.txt`)
+  returns a `SealKeyUnavailable` error listing the searched paths and how to fix it — so a missing
+  key surfaces immediately (in `exec` / `env export`·`github`·`dotenv`) rather than as a confusing
+  empty-credential failure downstream. A configured-but-missing `key_file` now also falls through
+  the rest of the precedence chain (so a local `key_file` no longer blocks an inline CI key).
+  `audit` is unaffected — it reads metadata only and still reports health without the key.
 - **`--dry-run` now runs the same schema validation as the real write** across `secret`
   subcommands. Previously a dry-run could preview a change (e.g. `expires = ""`) that the
   actual write would then reject, so the preview no longer misrepresents what will be

--- a/src/core/boot.ts
+++ b/src/core/boot.ts
@@ -82,7 +82,14 @@ const materializeInlineKey = (key: string): IdentitySource => {
  */
 const resolveSealIdentity = (config: EnvpktConfig, configDir: string): Option<IdentitySource> => {
   if (config.identity?.key_file) {
-    return Option<IdentitySource>({ path: resolve(configDir, expandPath(config.identity.key_file)), dispose: noop })
+    // Existence-check the configured key file. If it's missing, fall through to the rest of the
+    // precedence chain (ENVPKT_AGE_KEY_FILE → inline → default) rather than returning a dead path
+    // — so a config that declares a local key_file still resolves an inline CI key, and a truly
+    // absent key surfaces as SealKeyUnavailable rather than a downstream decrypt failure.
+    const keyFilePath = resolve(configDir, expandPath(config.identity.key_file))
+    if (existsSync(keyFilePath)) {
+      return Option<IdentitySource>({ path: keyFilePath, dispose: noop })
+    }
   }
   const envFile = process.env["ENVPKT_AGE_KEY_FILE"]
   if (envFile && existsSync(envFile)) {
@@ -97,6 +104,22 @@ const resolveSealIdentity = (config: EnvpktConfig, configDir: string): Option<Id
     return Option<IdentitySource>({ path: defaultPath, dispose: noop })
   }
   return Option<IdentitySource>(undefined)
+}
+
+/** Describe the seal-identity precedence chain with per-entry status, for a clear no-key error. */
+const describeSealKeySearch = (config: EnvpktConfig, configDir: string): ReadonlyArray<string> => {
+  const keyFile = config.identity?.key_file
+  const keyFileLine = keyFile
+    ? `identity.key_file → ${resolve(configDir, expandPath(keyFile))} (${existsSync(resolve(configDir, expandPath(keyFile))) ? "found" : "missing"})`
+    : `identity.key_file (not set)`
+  const envFile = process.env["ENVPKT_AGE_KEY_FILE"]
+  const envFileLine = envFile
+    ? `ENVPKT_AGE_KEY_FILE → ${envFile} (${existsSync(envFile) ? "found" : "missing"})`
+    : `ENVPKT_AGE_KEY_FILE (unset)`
+  const inlineLine = resolveInlineKey().isEmpty ? `ENVPKT_AGE_KEY (unset)` : `ENVPKT_AGE_KEY (set, inline)`
+  const defaultPath = join(homedir(), ".envpkt", "age-key.txt")
+  const defaultLine = `${defaultPath} (${existsSync(defaultPath) ? "found" : "missing"})`
+  return [keyFileLine, envFileLine, inlineLine, defaultLine]
 }
 
 const resolveIdentityKey = (config: EnvpktConfig, configDir: string): IdentityKeyResult => {
@@ -232,6 +255,21 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
         const fnoxKeys = detectFnoxKeys(configDir)
         const audit = computeAudit(config, fnoxKeys, undefined, aliasTable)
 
+        // Fail fast: sealed values are declared but no decryption key resolves anywhere. We cannot
+        // produce the declared values, so refuse rather than inject empty — even under warnOnly
+        // (which governs soft issues like expiry, not an absent key). Resolved once here and
+        // threaded into Phase 1 below so an inline key is materialized a single time.
+        const sealIdentity: Option<IdentitySource> = hasSealedValues
+          ? resolveSealIdentity(config, configDir)
+          : Option<IdentitySource>(undefined)
+        if (hasSealedValues && sealIdentity.isEmpty) {
+          return Left({
+            _tag: "SealKeyUnavailable" as const,
+            sealedKeys: nonAliasMetaKeys.filter((k) => !!nonAliasSecretEntries[k]?.encrypted_value),
+            searched: describeSealKeySearch(config, configDir),
+          })
+        }
+
         return checkExpiration(audit, failOnExpired, warnOnly).map((warnings) => {
           const secrets: Record<string, string> = {}
           const injected: string[] = []
@@ -279,12 +317,13 @@ export const bootSafe = (options?: BootOptions): Either<BootError, BootResult> =
           const sealedKeys = new Set<string>()
 
           if (hasSealedValues) {
-            resolveSealIdentity(config, configDir).fold(
+            sealIdentity.fold(
               () => {
+                // Unreachable — the SealKeyUnavailable guard above returns Left before we get here
+                // when hasSealedValues and no identity resolves. Kept as a defensive no-op.
                 log.warn("phase.sealed.no_identity_file", {
                   sealed_keys: nonAliasMetaKeys.filter((k) => !!nonAliasSecretEntries[k]?.encrypted_value).length,
                 })
-                warnings.push("Sealed values found but no identity file available for decryption")
               },
               ({ path: idPath, dispose }) => {
                 // eslint-disable-next-line functype/prefer-either -- try/finally is resource cleanup (temp key file), not error handling
@@ -468,6 +507,19 @@ const formatBootError = (error: BootError): string => {
       return `Decrypt failed: ${error.message}`
     case "IdentityNotFound":
       return `Identity file not found: ${error.path}`
+    case "SealKeyUnavailable": {
+      const keys = error.sealedKeys.length
+      const searched = error.searched.map((line) => `  • ${line}`).join("\n")
+      return [
+        `${keys} sealed secret(s) can't be decrypted — no age key found.`,
+        `Searched (in order):`,
+        searched,
+        `Fix one:`,
+        `  • Restore your key to ~/.envpkt/age-key.txt (or set ENVPKT_AGE_KEY_FILE / ENVPKT_AGE_KEY)`,
+        `  • Re-provision from source: envpkt seal --edit <KEY>`,
+        `Refusing to inject empty values for sealed secrets.`,
+      ].join("\n")
+    }
     case "AliasInvalidSyntax":
     case "AliasTargetMissing":
     case "AliasSelfReference":

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -230,6 +230,13 @@ export type BootError =
   | CatalogError
   | AliasError
   | { readonly _tag: "AuditFailed"; readonly audit: AuditResult; readonly message: string }
+  | {
+      // Sealed values are declared but no decryption key resolves anywhere. Hard error
+      // (never inject empty). `searched` lists the precedence chain with per-entry status.
+      readonly _tag: "SealKeyUnavailable"
+      readonly sealedKeys: ReadonlyArray<string>
+      readonly searched: ReadonlyArray<string>
+    }
   | IdentityError
 
 export type IdentityError =

--- a/test/core/boot.spec.ts
+++ b/test/core/boot.spec.ts
@@ -515,6 +515,91 @@ describe("boot with sealed values", () => {
   })
 })
 
+describe("bootSafe fail-fast on missing seal key (B1)", () => {
+  const FAKE_CIPHERTEXT = ["-----BEGIN AGE ENCRYPTED FILE-----", "ZmFrZQ==", "-----END AGE ENCRYPTED FILE-----"].join(
+    "\n",
+  )
+
+  let savedHome: string | undefined
+  let savedKey: string | undefined
+  let savedKeyFile: string | undefined
+  let isolatedHome: string
+
+  beforeEach(() => {
+    // Neutralize every key source so resolveSealIdentity finds nothing:
+    // HOME → empty tmp (no ~/.envpkt/age-key.txt), and clear the inline/file env keys.
+    isolatedHome = mkdtempSync(join(tmpdir(), "envpkt-home-"))
+    savedHome = process.env["HOME"]
+    savedKey = process.env["ENVPKT_AGE_KEY"]
+    savedKeyFile = process.env["ENVPKT_AGE_KEY_FILE"]
+    process.env["HOME"] = isolatedHome
+    delete process.env["ENVPKT_AGE_KEY"]
+    delete process.env["ENVPKT_AGE_KEY_FILE"]
+  })
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env["HOME"]
+    else process.env["HOME"] = savedHome
+    if (savedKey === undefined) delete process.env["ENVPKT_AGE_KEY"]
+    else process.env["ENVPKT_AGE_KEY"] = savedKey
+    if (savedKeyFile === undefined) delete process.env["ENVPKT_AGE_KEY_FILE"]
+    else process.env["ENVPKT_AGE_KEY_FILE"] = savedKeyFile
+    rmSync(isolatedHome, { recursive: true, force: true })
+  })
+
+  const sealedConfig = (extraIdentityLines: ReadonlyArray<string> = []): string =>
+    writeConfig(
+      [
+        `version = 1`,
+        `[identity]`,
+        `name = "x"`,
+        `recipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"`,
+        ...extraIdentityLines,
+        `[secret.SEALED_KEY]`,
+        `service = "test"`,
+        `encrypted_value = """`,
+        FAKE_CIPHERTEXT,
+        `"""`,
+      ].join("\n"),
+    )
+
+  it("returns SealKeyUnavailable when sealed values exist and no key resolves", () => {
+    const result = bootSafe({ configPath: sealedConfig(), inject: false })
+    result.fold(
+      (err) => expect(err._tag).toBe("SealKeyUnavailable"),
+      () => expect.unreachable("Expected Left(SealKeyUnavailable)"),
+    )
+  })
+
+  it("fails fast even under warnOnly (the export/exec path)", () => {
+    const result = bootSafe({ configPath: sealedConfig(), inject: false, warnOnly: true })
+    expect(result.isLeft()).toBe(true)
+    result.fold(
+      (err) => expect(err._tag).toBe("SealKeyUnavailable"),
+      () => expect.unreachable("Expected Left"),
+    )
+  })
+
+  it("treats a configured-but-missing key_file as no key, and lists searched paths", () => {
+    const result = bootSafe({ configPath: sealedConfig([`key_file = "missing-key.txt"`]), inject: false })
+    result.fold(
+      (err) => {
+        expect(err._tag).toBe("SealKeyUnavailable")
+        if (err._tag === "SealKeyUnavailable") {
+          expect(err.sealedKeys).toContain("SEALED_KEY")
+          expect(err.searched.join("\n")).toMatch(/missing-key\.txt/)
+        }
+      },
+      () => expect.unreachable("Expected Left(SealKeyUnavailable)"),
+    )
+  })
+
+  it("does not fail when there are no sealed values (no key needed)", () => {
+    const configPath = writeConfig([`version = 1`, `[secret.PLAIN]`, `service = "test"`].join("\n"))
+    expect(bootSafe({ configPath, inject: false }).isRight()).toBe(true)
+  })
+})
+
 describe("bootSafe with aliases", () => {
   it.skipIf(!ageInstalled)("secret alias inherits target's sealed value", () => {
     const keygenOutput = execFileSync("age-keygen", [], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" })


### PR DESCRIPTION
First step of the "File-Scoped Export, Shell-Hook Injection & Fail-Fast Key Handling" plan (Track B1). Independent and high-value, so it lands first.

## The incident

A namespaced project package (`CIV__*`) launched its MCP servers with **empty** credentials → "No teams found", three layers from the cause. Root cause: the package's age key was absent on that machine, and the boot/inject path only **warned** and resolved the sealed secrets to empty instead of failing.

## Fix

`bootSafe()` now returns a hard **`SealKeyUnavailable`** error the moment a package has `encrypted_value` entries and no key resolves — **before** any empty injection. The message lists the searched precedence chain with per-path status + remediation:

```
N sealed secret(s) can't be decrypted — no age key found.
Searched (in order):
  • identity.key_file → /path/keys/proj.txt (missing)
  • ENVPKT_AGE_KEY_FILE (unset)
  • ENVPKT_AGE_KEY (unset)
  • ~/.envpkt/age-key.txt (missing)
Fix one:
  • Restore your key to ~/.envpkt/age-key.txt (or set ENVPKT_AGE_KEY_FILE / ENVPKT_AGE_KEY)
  • Re-provision from source: envpkt seal --edit <KEY>
Refusing to inject empty values for sealed secrets.
```

- Applies to `exec` and the emit commands (`env export`/`github`/`dotenv`) via the shared `bootSafe` path, and fires **even under `warnOnly`** — a missing key is not a soft issue like expiry.
- **`audit` is unaffected** — it reads metadata only (no boot/decrypt), so it still reports health for a packet whose key you don't hold, which is correct.

## Drive-by fix in `resolveSealIdentity`

A configured `key_file` was returned **without an existence check**, so a missing per-package key produced a dead path → downstream decrypt failure, and never fell through to an inline `ENVPKT_AGE_KEY`. Now it's existence-checked and falls through the rest of the precedence chain when missing — so a local `key_file` no longer blocks an inline CI key, and a truly absent key reaches the new guard.

## Scope

- The **seal** path already fails fast correctly (`seal.ts` `--reseal` requires the key); this gap was specific to boot/inject — no duplication added there.
- Decrypt failure with a **present-but-wrong/corrupt** key remains a warning — noted as a separate follow-up.

## Testing

- 4 new `boot.spec.ts` tests (no `age` needed — the guard fires before decryption): sealed+no-key → `SealKeyUnavailable`; fails under `warnOnly`; configured-but-missing `key_file` is treated as no-key and lists the searched paths; no sealed values → no key required. `HOME` is isolated + key env vars cleared so the suite is deterministic regardless of the machine's `~/.envpkt/age-key.txt`.
- Full `pnpm validate` green: format, lint, typecheck, **545 tests** (+4), schema, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)