### PR TITLE
feat(seal): confirm before --edit overwrites an already-sealed value (Track B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`envpkt seal --edit` now confirms before overwriting an already-sealed value.** Replacing a
+  sealed `encrypted_value` discards the only ciphertext, so `--edit` asks `Replace the sealed
+value for <KEY>? [y/N]` first (declining keeps the existing value). Editing an unsealed entry is
+  unaffected. Makes the "lost the key, re-provision from source" path a deliberate act.
 - **`envpkt env export` no longer emits secret values by default.** With the new `scope` field
   defaulting to `"exec"`, ambient `eval "$(envpkt env export)"` now exports only env defaults; add
   top-level `scope = "shell"` to a package to restore secret export (e.g. for a global package

--- a/docs/plans/2026-06-09-file-scoped-export-shell-hook-failfast.md
+++ b/docs/plans/2026-06-09-file-scoped-export-shell-hook-failfast.md
@@ -228,7 +228,7 @@ Now promoted to a distinct, hard error:
   gap was specific to **boot/inject**. Decrypt failure with a _present_ key (wrong/corrupt) remains
   a warning for now — separate follow-up.
 
-### B2. Make `seal --edit` a deliberate "start over" (`src/cli/commands/seal.ts`)
+### B2. Make `seal --edit` a deliberate "start over" (`src/cli/commands/seal.ts`) — ✅ done
 
 `--edit` is the no-original-key recovery path (re-type values from your source of truth, reseal
 against the current recipient). Harden it so overwriting a sealed value is a conscious act:

--- a/src/cli/commands/seal.ts
+++ b/src/cli/commands/seal.ts
@@ -6,6 +6,7 @@ import { List, Option, Set } from "functype"
 import { expandPath, loadConfig, resolveConfigPath } from "../../core/config.js"
 import { resolveKeyPath } from "../../core/keygen.js"
 import { resolveValues } from "../../core/resolve-values.js"
+import type { SecretMeta } from "../../core/schema.js"
 import { sealSecrets, unsealSecrets } from "../../core/seal.js"
 import { unwrapAgentKey } from "../../fnox/identity.js"
 import { BOLD, CYAN, DIM, formatConfigSource, formatError, GREEN, RED, RESET, YELLOW } from "../output.js"
@@ -147,6 +148,45 @@ export const applySealedToml = (raw: string, sealedMeta: Record<string, { encryp
   return final.output.join("\n")
 }
 
+/** Affirmative answer to a `[y/N]` confirm prompt. */
+const isAffirmative = (answer: string): boolean => /^y(es)?$/i.test(answer.trim())
+
+/**
+ * Collect new plaintext values for the `--edit`ed keys via the injected `prompt`. Before
+ * overwriting an entry that is **already sealed** (`encrypted_value` present), require an
+ * explicit confirmation — replacing it discards the only ciphertext, and the prior value
+ * can't be recovered without the original key. Declined or empty entries are skipped (reported
+ * via `onSkip`). I/O flows only through `prompt`/`onSkip`, so the confirm/skip logic is
+ * unit-testable without a TTY.
+ */
+export const collectEditedValues = async (
+  editKeys: ReadonlyArray<string>,
+  entries: Readonly<Record<string, SecretMeta>>,
+  prompt: (question: string) => Promise<string>,
+  onSkip?: (key: string, reason: "declined" | "empty") => void,
+): Promise<Record<string, string>> => {
+  const values: Record<string, string> = {}
+  // eslint-disable-next-line functype/no-imperative-loops -- sequential await required for interactive prompts
+  for (const key of editKeys) {
+    if (entries[key]?.encrypted_value) {
+      const confirm = await prompt(
+        `Replace the sealed value for ${key}? The previous value can't be recovered without the original key. [y/N] `,
+      )
+      if (!isAffirmative(confirm)) {
+        onSkip?.(key, "declined")
+        continue
+      }
+    }
+    const value = await prompt(`Enter new value for ${key}: `)
+    if (value === "") {
+      onSkip?.(key, "empty")
+      continue
+    }
+    values[key] = value
+  }
+  return values
+}
+
 /** Write sealed values back into the TOML file, preserving structure. */
 const writeSealedToml = (configPath: string, sealedMeta: Record<string, { encrypted_value?: string }>): void => {
   const raw = readFileSync(configPath, "utf-8")
@@ -262,16 +302,11 @@ export const runSeal = async (options: SealOptions): Promise<void> => {
         rl.question(question, (answer) => resolve(answer))
       })
 
-    const values: Record<string, string> = {}
-    // eslint-disable-next-line functype/no-imperative-loops -- sequential await required for interactive prompts
-    for (const key of editKeys) {
-      const value = await prompt(`Enter new value for ${key}: `)
-      if (value === "") {
-        console.error(`${YELLOW}Skipped${RESET} ${key} (empty value)`)
-        continue
-      }
-      values[key] = value
-    }
+    const values = await collectEditedValues(editKeys, secretEntries, prompt, (key, reason) => {
+      console.error(
+        `${YELLOW}Skipped${RESET} ${key} (${reason === "empty" ? "empty value" : "kept existing sealed value"})`,
+      )
+    })
     rl.close()
 
     if (Object.keys(values).length === 0) {

--- a/test/cli/seal.spec.ts
+++ b/test/cli/seal.spec.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url"
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
+import { collectEditedValues } from "../../src/cli/commands/seal.js"
 import { loadConfig } from "../../src/core/config.js"
 
 const __testDir = dirname(fileURLToPath(import.meta.url))
@@ -115,5 +116,58 @@ from_key = "secret.REAL_KEY"
     expect(status).toBe(2)
     expect(stdout).toContain("alias")
     expect(stdout).toContain("from_key")
+  })
+})
+
+describe("collectEditedValues (--edit confirm-on-overwrite)", () => {
+  // Fake prompt that answers based on the question text, recording every prompt shown.
+  const scriptedPrompt = (answers: { confirm?: string; value?: string }, asked: string[]) => {
+    return (question: string): Promise<string> => {
+      asked.push(question)
+      if (question.startsWith("Replace the sealed value")) return Promise.resolve(answers.confirm ?? "")
+      return Promise.resolve(answers.value ?? "")
+    }
+  }
+
+  const sealed = { S: { service: "x", encrypted_value: "ct" } }
+  const unsealed = { U: { service: "x" } }
+
+  it("does not prompt for confirmation on an unsealed entry", async () => {
+    const asked: string[] = []
+    const values = await collectEditedValues(["U"], unsealed, scriptedPrompt({ value: "newval" }, asked))
+    expect(values).toEqual({ U: "newval" })
+    expect(asked.some((q) => q.startsWith("Replace the sealed value"))).toBe(false)
+  })
+
+  it("confirms before overwriting an already-sealed entry, and skips on a non-affirmative answer", async () => {
+    const asked: string[] = []
+    const skips: string[] = []
+    const values = await collectEditedValues(
+      ["S"],
+      sealed,
+      scriptedPrompt({ confirm: "n", value: "newval" }, asked),
+      (k) => skips.push(k),
+    )
+    expect(asked[0]).toContain("Replace the sealed value for S?")
+    expect(values).toEqual({}) // declined → not changed, value never prompted/applied
+    expect(skips).toEqual(["S"])
+    // value prompt must not have been reached after declining
+    expect(asked.some((q) => q.startsWith("Enter new value"))).toBe(false)
+  })
+
+  it("overwrites a sealed entry when the confirmation is affirmative", async () => {
+    const asked: string[] = []
+    const values = await collectEditedValues(["S"], sealed, scriptedPrompt({ confirm: "y", value: "fresh" }, asked))
+    expect(values).toEqual({ S: "fresh" })
+    expect(asked.some((q) => q.startsWith("Enter new value for S"))).toBe(true)
+  })
+
+  it("skips an empty value even after an affirmative confirm", async () => {
+    const skips: string[] = []
+    const values = await collectEditedValues(["S"], sealed, scriptedPrompt({ confirm: "yes", value: "" }, []), (k, r) =>
+      skips.push(`${k}:${r}`),
+    )
+    expect(values).toEqual({})
+    expect(skips).toEqual(["S:empty"])
   })
 })


### PR DESCRIPTION
Track B2 of the shell-hook + fail-fast plan — the small safety guard on the "start over" path.

## What

`envpkt seal --edit` re-provisions a secret from a freshly typed value (used when you've lost the original key and want to re-enter it from source). Overwriting an entry that's **already sealed** discards the only ciphertext — and the prior value can't be recovered without the original key. So `--edit` now confirms first:

```
Replace the sealed value for STRIPE_KEY? The previous value can't be recovered without the original key. [y/N]
```

Declining keeps the existing sealed value. Editing an **unsealed** entry is unchanged (nothing to overwrite → no confirm). This makes the destructive replace a deliberate act, matching the plan's "deliberate start-over" principle.

## How (testability)

`--edit` is interactive-only (requires a TTY), so it can't be driven by `spawnSync`. I extracted the value-collection-with-confirm into:

```ts
collectEditedValues(editKeys, entries, prompt, onSkip)  // prompt is injectable
```

`runSeal` wires the real `readline` around it; tests inject a scripted `prompt` and assert the confirm/skip logic with **no TTY and no age** required. Covered:
- unsealed entry → no confirmation prompt
- sealed entry + decline (`n`) → value unchanged, value-prompt never reached
- sealed entry + affirmative (`y`) → overwritten
- empty value after confirm → skipped

`--reseal` (the key-present rotation path) is untouched — it already requires the original key and never prompts for an already-sealed value's plaintext.

## Testing

- 4 new `collectEditedValues` unit tests.
- Full `pnpm validate` green: format, lint, typecheck, **560 tests**, schema, build.

CHANGELOG updated (Changed); plan B2 marked ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)