### PR TITLE
fix(shell-hook): decouple explicit export, surface errors on cd, +init --global (0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`envpkt init --global`** scaffolds an ambient package with `scope = "shell"` baked in; a plain
+  `--scope <shell|exec>` flag scaffolds either explicitly. (The global package is the one meant to
+  load ambiently — so its generator now defaults it correctly instead of the project default.)
+- **`envpkt shell-hook --no-audit`** omits the on-`cd` credential-health line from the emitted hook
+  (for slower machines where the per-entry `audit` spawn isn't wanted).
+
+### Changed
+
+- **`envpkt env export` emits secrets again on the explicit path; `scope` now gates only the
+  ambient hook (`--track`).** 0.13.0 gated *all* `env export`, which broke `eval "$(envpkt env
+  export)"` setups that load a package's secrets at login. Plain `env export` now behaves like
+  0.12.0 (emits everything); only `env export --track` — the path the shell hook uses — respects
+  `scope`. So explicit invocations never silently withhold, while ambient `cd`-loading stays
+  scoped. (Reverts the 0.13.0 breaking change on the explicit path.)
+
+### Fixed
+
+- **The shell hook now surfaces a missing-key error on `cd`** instead of swallowing it. The hook
+  no longer `2>/dev/null`s the inject, and `env export --track` is quiet on success (so there's no
+  routine-warning noise) but prints a `SealKeyUnavailable` error — now rendered with the searched
+  key paths and remediation in `formatError`, not just the bare tag.
+- **bash hook handles an array-valued `PROMPT_COMMAND`** (bash ≥5.1): it appends to the array
+  rather than string-concatenating (which previously discarded all but the first element).
+
 ## [0.13.0] - 2026-06-12
 
 ### Added

--- a/site/src/content/docs/cli/env-export.mdx
+++ b/site/src/content/docs/cli/env-export.mdx
@@ -20,19 +20,22 @@ envpkt env export [options]
 | `--skip-audit`        | Skip the pre-flight audit                                                | `false`       |
 | `--track`             | Emit prior-value snapshots + an `_ENVPKT_INJECTED` list for a shell hook | `false`       |
 
-## Scope: secrets are withheld unless opted in
+## Scope and the explicit vs. ambient paths
 
-Putting **secret** values into your ambient shell is gated by the top-level
-[`scope`](/reference/toml-schema/) field:
+Plain `envpkt env export` is an **explicit** invocation — it emits all resolved secrets (and env
+defaults), regardless of the package's [`scope`](/reference/toml-schema/). So
+`eval "$(envpkt env export)"` loads everything, as you'd expect.
 
-- `scope = "exec"` (**default**) — `env export` emits only **env defaults**; secrets are
-  withheld (a one-line note goes to stderr). Use [`envpkt exec`](/cli/exec/) to run a tool with
-  the secrets scoped to that process.
-- `scope = "shell"` — `env export` also emits secret values, for `eval`-ing into your shell
-  (e.g. a global package loaded at shell start).
+`scope` only gates the **ambient** path — `env export --track`, which the
+[shell hook](/cli/shell-hook/) uses to load credentials automatically on `cd`:
 
-`scope` only governs this ambient path. `envpkt exec`, [`env github`](/cli/env-github/), and
-[`env dotenv`](/cli/env-dotenv/) always resolve everything regardless of `scope`.
+- `scope = "exec"` (**default**) — `--track` emits only **env defaults**; secrets are withheld
+  (use [`envpkt exec`](/cli/exec/) for those).
+- `scope = "shell"` — `--track` also emits secret values, so the hook loads them ambiently.
+
+This keeps an explicit `env export` from ever silently withholding, while ambient `cd`-loading
+stays scoped. `envpkt exec`, [`env github`](/cli/env-github/), and [`env dotenv`](/cli/env-dotenv/)
+always resolve everything regardless of `scope`.
 
 ## Examples
 

--- a/site/src/content/docs/cli/shell-hook.mdx
+++ b/site/src/content/docs/cli/shell-hook.mdx
@@ -11,8 +11,12 @@ one-line credential-health warning.
 ## Usage
 
 ```bash
-envpkt shell-hook <shell>     # shell: zsh | bash
+envpkt shell-hook <shell>              # shell: zsh | bash
+envpkt shell-hook <shell> --no-audit   # omit the on-cd health-check line
 ```
+
+`--no-audit` drops step 4 (the `audit` spawn) from the emitted hook — useful on slower machines
+where you don't want the per-package-entry health check.
 
 ## Setup
 

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -303,24 +303,21 @@ const runEnvExport = (options: ExportOptions): void => {
       process.exit(2)
     },
     (boot) => {
-      emitWarnings(boot)
+      // `--track` is the ambient shell-hook path: stay quiet (no routine warnings) so the eval'd
+      // output is clean, and gate secrets by the package's `scope`. Plain `env export` is an
+      // explicit invocation — emit everything and show warnings, exactly like 0.12.0. Either way
+      // a hard error (e.g. SealKeyUnavailable) is printed by the Left branch above and surfaces.
+      if (!options.track) emitWarnings(boot)
 
-      // Secrets are emitted into the ambient shell only when the package opts in with
-      // top-level `scope = "shell"`. Default `exec` withholds them (use `envpkt exec`).
-      // Env defaults (non-secret) are always emitted. `scope` never affects `exec`/`github`/`dotenv`.
+      // Scope only gates the ambient (`--track`) path. Default `exec` withholds secrets there;
+      // `shell` emits them. `scope` never affects plain `env export`, `exec`, `github`, or `dotenv`.
       const scope = loadConfig(boot.configPath).fold(
         () => "exec",
         (config) => config.scope ?? "exec",
       )
+      const gateSecrets = options.track === true && scope !== "shell"
       const entries = collectEmitEntries(boot)
-      const emit = scope === "shell" ? entries : entries.filter((e) => !e.secret)
-
-      const withheld = entries.length - emit.length
-      if (withheld > 0) {
-        console.error(
-          `${DIM}${withheld} secret(s) withheld (scope="${scope}") — use \`envpkt exec\` or set top-level scope="shell".${RESET}`,
-        )
-      }
+      const emit = gateSecrets ? entries.filter((e) => !e.secret) : entries
 
       // Emit under the namespaced wire name so `eval "$(envpkt env export)"` sets the
       // variable the consumer actually reads. With --track, wrap each assignment in an

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -19,7 +19,14 @@ type InitOptions = {
   readonly capabilities?: string
   readonly expires?: string
   readonly force?: boolean
+  readonly scope?: string
+  readonly global?: boolean
 }
+
+/** Resolve the top-level `scope` to scaffold: explicit --scope wins; --global implies "shell". */
+// eslint-disable-next-line functype/prefer-option -- thin scaffold helper; undefined = omit the line
+const resolveInitScope = (options: InitOptions): string | undefined =>
+  options.scope ?? (options.global ? "shell" : undefined)
 
 const todayIso = (): string => new Date().toISOString().split("T")[0]!
 
@@ -57,6 +64,10 @@ const generateTemplate = (options: InitOptions, fnoxKeys?: ReadonlyArray<string>
   lines.push(`#:schema https://raw.githubusercontent.com/jordanburke/envpkt/main/schemas/envpkt.schema.json`)
   lines.push(``)
   lines.push(`version = 1`)
+  const scope = resolveInitScope(options)
+  if (scope) {
+    lines.push(`scope = "${scope}"   # shell = secrets load ambiently on cd/eval; exec = only via envpkt exec`)
+  }
   lines.push(``)
 
   if (options.catalog) {
@@ -135,6 +146,11 @@ const formatConfigError = (err: ConfigError): string => {
 
 export const runInit = (dir: string, options: InitOptions): void => {
   const outPath = join(dir, CONFIG_FILENAME)
+
+  if (options.scope !== undefined && options.scope !== "shell" && options.scope !== "exec") {
+    console.error(`${RED}Error:${RESET} --scope must be "shell" or "exec" (got "${options.scope}")`)
+    process.exit(1)
+  }
 
   if (existsSync(outPath) && !options.force) {
     console.error(`${RED}Error:${RESET} ${CONFIG_FILENAME} already exists. Use --force to overwrite.`)

--- a/src/cli/commands/shell-hook.ts
+++ b/src/cli/commands/shell-hook.ts
@@ -1,97 +1,115 @@
 import { RED, RESET } from "../output.js"
 
-// On directory change the hook:
+type ShellHookOptions = {
+  readonly audit?: boolean
+}
+
+// The hook, on each directory change:
 //   1. dedups on the resolved config path (no-op when cd stays inside the same package),
 //   2. restores the previously-injected package (prior values, not blind unset),
-//   3. injects the new directory's package via `env export --track` (scope="shell" only),
-//   4. prints a credential-health warning via `audit`.
-// `envpkt config-path` is resolve-only (no decrypt), so the per-cd gate is cheap. Only the
-// `env export` step decrypts, and only when the resolved package actually changed.
+//   3. injects the new directory's package via `env export --track` (scope="shell" secrets only),
+//   4. optionally prints a credential-health warning via `audit` (omit with --no-audit).
 //
-// In these template literals, only `\${...}` brace-expansions and backticks are escaped — every
-// other `$` (`$k`, `$cfg`, `$(...)`) is literal shell and needs no escape.
+// `env export --track` is quiet on success and prints only hard errors (e.g. a missing seal key)
+// to stderr — so the inject is NOT stderr-suppressed here, letting those errors surface on cd.
+// `config-path`/`audit` ARE stderr-suppressed (resolve-only / health noise).
+//
+// Built from single-quoted line arrays so `$`, `${...}` and `"` are all literal shell — no escaping.
 
-const ZSH_HOOK = `# envpkt shell hook — add to ~/.zshrc:  eval "$(envpkt shell-hook zsh)"
-# Loads a project envpkt.toml on cd (secrets only for scope="shell" packages), restores the
-# prior environment on leave, and warns on credential health. Use \`envpkt exec\` for scope="exec".
-_envpkt_restore() {
-  [[ -n "$_ENVPKT_INJECTED" ]] || return
-  local k had prev
-  for k in \${(s: :)_ENVPKT_INJECTED}; do
-    had="_ENVPKT_HAD_$k"
-    prev="_ENVPKT_PREV_$k"
-    if [[ -n "\${(P)had}" ]]; then
-      export "$k=\${(P)prev}"
-    else
-      unset "$k"
-    fi
-    unset "$had" "$prev"
-  done
-  unset _ENVPKT_INJECTED
-}
+const zshHook = (audit: boolean): string =>
+  [
+    '# envpkt shell hook — add to ~/.zshrc:  eval "$(envpkt shell-hook zsh)"',
+    "# Loads the current directory package on cd, restores the prior env on leave, warns on health.",
+    "_envpkt_restore() {",
+    '  [[ -n "$_ENVPKT_INJECTED" ]] || return',
+    "  local k had prev",
+    "  for k in ${(s: :)_ENVPKT_INJECTED}; do",
+    '    had="_ENVPKT_HAD_$k"',
+    '    prev="_ENVPKT_PREV_$k"',
+    '    if [[ -n "${(P)had}" ]]; then',
+    '      export "$k=${(P)prev}"',
+    "    else",
+    '      unset "$k"',
+    "    fi",
+    '    unset "$had" "$prev"',
+    "  done",
+    "  unset _ENVPKT_INJECTED",
+    "}",
+    "",
+    "_envpkt_chpwd() {",
+    "  local cfg",
+    '  cfg="$(envpkt config-path 2>/dev/null)"',
+    '  [[ "$cfg" == "$_ENVPKT_DIR" ]] && return',
+    "  _envpkt_restore",
+    '  _ENVPKT_DIR="$cfg"',
+    '  [[ -z "$cfg" ]] && return',
+    '  eval "$(envpkt env export --track)"',
+    ...(audit ? ["  envpkt audit --format minimal 2>/dev/null"] : []),
+    "}",
+    "",
+    "autoload -Uz add-zsh-hook",
+    "add-zsh-hook chpwd _envpkt_chpwd",
+    "_envpkt_chpwd",
+    "",
+  ].join("\n")
 
-_envpkt_chpwd() {
-  local cfg
-  cfg="$(envpkt config-path 2>/dev/null)"
-  [[ "$cfg" == "$_ENVPKT_DIR" ]] && return
-  _envpkt_restore
-  _ENVPKT_DIR="$cfg"
-  [[ -z "$cfg" ]] && return
-  eval "$(envpkt env export --track 2>/dev/null)"
-  envpkt audit --format minimal 2>/dev/null
-}
+const bashHook = (audit: boolean): string =>
+  [
+    '# envpkt shell hook — add to ~/.bashrc:  eval "$(envpkt shell-hook bash)"',
+    "# Loads the current directory package on cd, restores the prior env on leave, warns on health.",
+    "_envpkt_restore() {",
+    '  [ -n "$_ENVPKT_INJECTED" ] || return',
+    "  local k had prev",
+    "  for k in $_ENVPKT_INJECTED; do",
+    '    had="_ENVPKT_HAD_$k"',
+    '    prev="_ENVPKT_PREV_$k"',
+    '    if [ -n "${!had}" ]; then',
+    '      export "$k=${!prev}"',
+    "    else",
+    '      unset "$k"',
+    "    fi",
+    '    unset "$had" "$prev"',
+    "  done",
+    "  unset _ENVPKT_INJECTED",
+    "}",
+    "",
+    "_envpkt_prompt() {",
+    '  [ "$PWD" = "$_ENVPKT_PWD" ] && return',
+    '  _ENVPKT_PWD="$PWD"',
+    "  local cfg",
+    '  cfg="$(envpkt config-path 2>/dev/null)"',
+    '  [ "$cfg" = "$_ENVPKT_DIR" ] && return',
+    "  _envpkt_restore",
+    '  _ENVPKT_DIR="$cfg"',
+    '  [ -z "$cfg" ] && return',
+    '  eval "$(envpkt env export --track)"',
+    ...(audit ? ["  envpkt audit --format minimal 2>/dev/null"] : []),
+    "}",
+    "",
+    "# Register on PROMPT_COMMAND, handling both the string and (bash 5.1+) array forms.",
+    'if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then',
+    '  case " ${PROMPT_COMMAND[*]} " in',
+    '    *" _envpkt_prompt "*) ;;',
+    "    *) PROMPT_COMMAND+=(_envpkt_prompt) ;;",
+    "  esac",
+    "else",
+    '  case "$PROMPT_COMMAND" in',
+    "    *_envpkt_prompt*) ;;",
+    '    *) PROMPT_COMMAND="_envpkt_prompt${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;',
+    "  esac",
+    "fi",
+    "_envpkt_prompt",
+    "",
+  ].join("\n")
 
-autoload -Uz add-zsh-hook
-add-zsh-hook chpwd _envpkt_chpwd
-_envpkt_chpwd
-`
-
-const BASH_HOOK = `# envpkt shell hook — add to ~/.bashrc:  eval "$(envpkt shell-hook bash)"
-# Loads a project envpkt.toml on cd (secrets only for scope="shell" packages), restores the
-# prior environment on leave, and warns on credential health. Use \`envpkt exec\` for scope="exec".
-_envpkt_restore() {
-  [ -n "$_ENVPKT_INJECTED" ] || return
-  local k had prev
-  for k in $_ENVPKT_INJECTED; do
-    had="_ENVPKT_HAD_$k"
-    prev="_ENVPKT_PREV_$k"
-    if [ -n "\${!had}" ]; then
-      export "$k=\${!prev}"
-    else
-      unset "$k"
-    fi
-    unset "$had" "$prev"
-  done
-  unset _ENVPKT_INJECTED
-}
-
-_envpkt_prompt() {
-  [ "$PWD" = "$_ENVPKT_PWD" ] && return
-  _ENVPKT_PWD="$PWD"
-  local cfg
-  cfg="$(envpkt config-path 2>/dev/null)"
-  [ "$cfg" = "$_ENVPKT_DIR" ] && return
-  _envpkt_restore
-  _ENVPKT_DIR="$cfg"
-  [ -z "$cfg" ] && return
-  eval "$(envpkt env export --track 2>/dev/null)"
-  envpkt audit --format minimal 2>/dev/null
-}
-
-case "$PROMPT_COMMAND" in
-  *_envpkt_prompt*) ;;
-  *) PROMPT_COMMAND="_envpkt_prompt\${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
-esac
-_envpkt_prompt
-`
-
-export const runShellHook = (shell: string): void => {
+export const runShellHook = (shell: string, options?: ShellHookOptions): void => {
+  const audit = options?.audit !== false
   switch (shell) {
     case "zsh":
-      console.log(ZSH_HOOK)
+      console.log(zshHook(audit))
       break
     case "bash":
-      console.log(BASH_HOOK)
+      console.log(bashHook(audit))
       break
     default:
       console.error(`${RED}Error:${RESET} Unsupported shell: ${shell}. Use "zsh" or "bash".`)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -51,6 +51,8 @@ program
   .option("--name <name>", "Identity name (requires --identity)")
   .option("--capabilities <caps>", "Comma-separated capabilities (requires --identity)")
   .option("--expires <date>", "Credential expiration YYYY-MM-DD (requires --identity)")
+  .option("--scope <scope>", 'Top-level scope: "shell" (secrets load ambiently) or "exec" (only via envpkt exec)')
+  .option("--global", 'Scaffold a global/ambient package (implies scope = "shell")')
   .option("--force", "Overwrite existing envpkt.toml")
   .action((options) => {
     runInit(process.cwd(), options)
@@ -193,10 +195,11 @@ program
 
 program
   .command("shell-hook")
-  .description("Output shell function for ambient credential warnings on cd — combine with env export for full setup")
+  .description("Output a shell hook that loads a project's credentials on cd and restores them on leave")
   .argument("<shell>", "Shell type: zsh | bash")
-  .action((shell: string) => {
-    runShellHook(shell)
+  .option("--no-audit", "Omit the credential-health audit line from the emitted hook")
+  .action((shell: string, options) => {
+    runShellHook(shell, options)
   })
 
 program.parse()

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -180,6 +180,17 @@ export const formatError = (error: { _tag: string; message?: string; path?: stri
       return `${RED}Error:${RESET} Decrypt failed: ${error.message}`
     case "IdentityNotFound":
       return `${RED}Error:${RESET} Identity file not found: ${error.path}`
+    case "SealKeyUnavailable": {
+      const e = error as unknown as { sealedKeys: ReadonlyArray<string>; searched: ReadonlyArray<string> }
+      return [
+        `${RED}Error:${RESET} ${e.sealedKeys.length} sealed secret(s) can't be decrypted — no age key found.`,
+        `${DIM}Searched (in order):${RESET}`,
+        e.searched.map((l) => `  • ${l}`).join("\n"),
+        `${DIM}Fix one:${RESET}`,
+        `  • Restore your key to ~/.envpkt/age-key.txt (or set ENVPKT_AGE_KEY_FILE / ENVPKT_AGE_KEY)`,
+        `  • Re-provision from source: envpkt seal --edit <KEY>`,
+      ].join("\n")
+    }
     case "AuditFailed":
       return `${RED}Error:${RESET} Audit failed: ${error.message}`
     case "CatalogNotFound":

--- a/test/cli/env.spec.ts
+++ b/test/cli/env.spec.ts
@@ -307,7 +307,7 @@ describe("envpkt env export", () => {
     expect(tracked.stdout).toContain(`_ENVPKT_INJECTED='LOG_LEVEL'`)
   })
 
-  it.skipIf(!ageInstalled)("withholds sealed secrets at the default scope (exec)", () => {
+  it.skipIf(!ageInstalled)("plain export emits secrets at default scope; --track withholds them (decouple)", () => {
     const keygenOutput = execFileSync("age-keygen", [], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" })
     const recipient = keygenOutput
       .split("\n")
@@ -321,13 +321,20 @@ describe("envpkt env export", () => {
       stdio: ["pipe", "pipe", "pipe"],
     })
 
-    // No top-level scope → defaults to "exec" → secret withheld from ambient export.
+    // No top-level scope → defaults to "exec".
     const toml = `version = 1\n\n[identity]\nname = "test"\nrecipient = "${recipient}"\nkey_file = "identity.txt"\n\n[secret.MY_SECRET]\nservice = "test"\nencrypted_value = """\n${encrypted}"""\n`
     writeFileSync(join(tmpDir, "envpkt.toml"), toml)
 
-    const result = run(["env", "export"], { cwd: tmpDir })
-    expect(result.status).toBe(0)
-    expect(result.stdout).not.toContain("MY_SECRET")
+    // Explicit `env export` emits the secret regardless of scope (restored 0.12.0 behavior).
+    const plain = run(["env", "export"], { cwd: tmpDir })
+    expect(plain.status).toBe(0)
+    expect(plain.stdout).toContain("export MY_SECRET='sk-test-secret-value'")
+
+    // The ambient `--track` (hook) path respects scope: exec withholds the secret.
+    const tracked = run(["env", "export", "--track"], { cwd: tmpDir })
+    expect(tracked.status).toBe(0)
+    expect(tracked.stdout).not.toContain("sk-test-secret-value")
+    expect(tracked.stdout).not.toContain("MY_SECRET")
   })
 })
 

--- a/test/cli/init.spec.ts
+++ b/test/cli/init.spec.ts
@@ -27,6 +27,24 @@ describe("envpkt init", () => {
     expect(content).toContain("stale_warning_days = 90")
   })
 
+  it("--global scaffolds scope = shell", () => {
+    runInit(tmpDir, { global: true })
+    loadConfig(join(tmpDir, "envpkt.toml")).fold(
+      (err) => expect.unreachable(`should be valid: ${err._tag}`),
+      (c) => expect(c.scope).toBe("shell"),
+    )
+  })
+
+  it("--scope exec scaffolds scope = exec; default omits scope", () => {
+    runInit(tmpDir, { scope: "exec" })
+    expect(readFileSync(join(tmpDir, "envpkt.toml"), "utf-8")).toContain('scope = "exec"')
+
+    const plain = mkdtempSync(join(tmpdir(), "envpkt-init-noscope-"))
+    runInit(plain, {})
+    expect(readFileSync(join(plain, "envpkt.toml"), "utf-8")).not.toMatch(/^scope =/m)
+    rmSync(plain, { recursive: true, force: true })
+  })
+
   it("sets created date to today on generated secrets", () => {
     runInit(tmpDir, {})
 

--- a/test/cli/shell-hook.spec.ts
+++ b/test/cli/shell-hook.spec.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process"
+import { execFileSync, spawnSync } from "node:child_process"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
@@ -22,27 +22,35 @@ const shellAvailable = (sh: string): boolean => {
 const zshAvail = shellAvailable("zsh")
 const bashAvail = shellAvailable("bash")
 
-const emitHook = (shell: string): string => execFileSync(TSX, [CLI_SRC, "shell-hook", shell], { encoding: "utf-8" })
+const emitHook = (...args: string[]): string =>
+  execFileSync(TSX, [CLI_SRC, "shell-hook", ...args], { encoding: "utf-8" })
 
 describe("shell-hook output", () => {
-  it("zsh hook wires chpwd + dedup + --track inject + restore + audit, and runs once", () => {
+  it("zsh hook wires chpwd + dedup + restore + audit, runs once, and does NOT mute the inject", () => {
     const out = emitHook("zsh")
     expect(out).toContain("add-zsh-hook chpwd _envpkt_chpwd")
     expect(out).toContain("envpkt config-path")
-    expect(out).toContain("envpkt env export --track")
     expect(out).toContain("_envpkt_restore")
     expect(out).toContain("envpkt audit --format minimal")
+    // The inject must NOT suppress stderr — hard errors (SealKeyUnavailable) surface on cd.
+    expect(out).toContain('eval "$(envpkt env export --track)"')
+    expect(out).not.toContain("env export --track 2>/dev/null")
     // run-once on install (chpwd doesn't fire at shell start)
     expect(out.trimEnd().endsWith("_envpkt_chpwd")).toBe(true)
   })
 
-  it("bash hook wires PROMPT_COMMAND with a PWD guard + dedup", () => {
+  it("bash hook handles both string and array PROMPT_COMMAND", () => {
     const out = emitHook("bash")
-    expect(out).toContain("PROMPT_COMMAND")
-    expect(out).toContain('[ "$PWD" = "$_ENVPKT_PWD" ] && return')
-    expect(out).toContain("envpkt config-path")
-    expect(out).toContain("envpkt env export --track")
-    expect(out).toContain("_envpkt_restore")
+    expect(out).toContain('declare -a"*') // array-form detection
+    expect(out).toContain("PROMPT_COMMAND+=(_envpkt_prompt)") // array append
+    expect(out).toContain('PROMPT_COMMAND="_envpkt_prompt${PROMPT_COMMAND:+;$PROMPT_COMMAND}"') // string form
+    expect(out).toContain('eval "$(envpkt env export --track)"')
+  })
+
+  it("--no-audit omits the audit line", () => {
+    expect(emitHook("zsh")).toContain("envpkt audit --format minimal")
+    expect(emitHook("zsh", "--no-audit")).not.toContain("envpkt audit")
+    expect(emitHook("bash", "--no-audit")).not.toContain("envpkt audit")
   })
 
   it("rejects an unsupported shell with exit 1", () => {
@@ -65,7 +73,7 @@ describe("shell-hook integration", () => {
     pkg = mkdtempSync(join(tmpdir(), "envpkt-hook-pkg-"))
     empty = mkdtempSync(join(tmpdir(), "envpkt-hook-empty-"))
     home = mkdtempSync(join(tmpdir(), "envpkt-hook-home-"))
-    writeFileSync(join(pkg, "envpkt.toml"), 'version = 1\n\n[env.GREETING]\nvalue = "hi"\n')
+    writeFileSync(join(pkg, "envpkt.toml"), 'version = 1\nscope = "shell"\n\n[env.GREETING]\nvalue = "hi"\n')
     mkdirSync(join(pkg, "src", "lib"), { recursive: true })
   })
 
@@ -74,18 +82,18 @@ describe("shell-hook integration", () => {
   })
 
   // Isolate HOME (so the real global package isn't discovered) and clear config env vars.
-  const runShell = (shell: string, script: string): string => {
+  const runShell = (shell: string, script: string): { out: string; status: number } => {
     const env = { ...process.env, HOME: home, ENVPKT_SEARCH_PATH: "" }
     delete (env as Record<string, string | undefined>)["ENVPKT_CONFIG"]
     const shim = `envpkt() { "${TSX}" "${CLI_SRC}" "$@"; }\n`
-    return execFileSync(shell, ["-c", shim + script], { encoding: "utf-8", timeout: 60000, env })
+    const r = spawnSync(shell, ["-c", shim + script], { encoding: "utf-8", timeout: 60000, env })
+    return { out: (r.stdout ?? "") + (r.stderr ?? ""), status: r.status ?? 1 }
   }
 
   it.skipIf(!zshAvail)(
     "zsh: loads on cd, dedups in a subdir, unsets on leave",
     () => {
-      // chpwd fires in `zsh -c`, so cd alone drives the hook.
-      const out = runShell(
+      const { out } = runShell(
         "zsh",
         [
           `cd "${empty}"`,
@@ -95,10 +103,9 @@ describe("shell-hook integration", () => {
           `cd "${empty}";       printf 'C=[%s]\\n' "\${GREETING-unset}"`,
         ].join("\n"),
       )
-      expect(out).toContain("A=[hi]") // loaded from the package
+      expect(out).toContain("A=[hi]")
       expect(out).toContain("B=[hi]") // subdir resolves the same package (upward-walk + dedup)
-      expect(out).toContain("C=[unset]") // unset on leaving to a non-package dir
-      // Spawns several tsx cold-starts; well over vitest's 5s default on slower CI runners.
+      expect(out).toContain("C=[unset]")
     },
     60_000,
   )
@@ -106,8 +113,7 @@ describe("shell-hook integration", () => {
   it.skipIf(!bashAvail)(
     "bash: loads on cd and restores the prior value on leave",
     () => {
-      // PROMPT_COMMAND doesn't fire in non-interactive `bash -c`, so drive _envpkt_prompt directly.
-      const out = runShell(
+      const { out } = runShell(
         "bash",
         [
           `export GREETING=OUTER`,
@@ -117,8 +123,44 @@ describe("shell-hook integration", () => {
           `cd "${empty}"; _envpkt_prompt; printf 'C=[%s]\\n' "$GREETING"`,
         ].join("\n"),
       )
-      expect(out).toContain("A=[hi]") // package value loaded
+      expect(out).toContain("A=[hi]")
       expect(out).toContain("C=[OUTER]") // prior value restored, not blind-unset
+    },
+    60_000,
+  )
+
+  it.skipIf(!zshAvail)(
+    "zsh: a missing seal key surfaces on cd (inject is not stderr-muted)",
+    () => {
+      // Sealed package, scope=shell, no resolvable key (HOME isolated) → SealKeyUnavailable.
+      // The guard fires before decryption, so this needs no age.
+      const sealedPkg = mkdtempSync(join(tmpdir(), "envpkt-hook-sealed-"))
+      writeFileSync(
+        join(sealedPkg, "envpkt.toml"),
+        [
+          "version = 1",
+          'scope = "shell"',
+          "[identity]",
+          'name = "t"',
+          'recipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"',
+          "[secret.API_KEY]",
+          'service = "s"',
+          'encrypted_value = """',
+          "-----BEGIN AGE ENCRYPTED FILE-----",
+          "ZmFrZQ==",
+          "-----END AGE ENCRYPTED FILE-----",
+          '"""',
+        ].join("\n"),
+      )
+      try {
+        const { out } = runShell(
+          "zsh",
+          [`cd "${empty}"`, `eval "$(envpkt shell-hook zsh)"`, `cd "${sealedPkg}"`].join("\n"),
+        )
+        expect(out).toMatch(/no age key|can't be decrypted/)
+      } finally {
+        rmSync(sealedPkg, { recursive: true, force: true })
+      }
     },
     60_000,
   )


### PR DESCRIPTION
A correctness pass on the shell-hook work, plus the explicit-export regression introduced in 0.13.0. Six items (the four you flagged + the two prior approvals):

## Changed
**Decouple `env export` from `scope`.** 0.13.0 gated *all* `env export`, which broke `eval "$(envpkt env export)"` setups that load secrets at login. Now:
- **plain `env export`** (explicit) emits everything, like 0.12.0 — never silently withholds;
- **`env export --track`** (the hook's ambient path) respects `scope` (exec withholds secrets, shell emits).

This is the real fix for the regression — you don't even need the `scope = "shell"` line on a global package for explicit export to work (though it's still correct to have).

## Fixed
- **Missing-key errors now surface on `cd`.** The hook no longer `2>/dev/null`s the inject, and `env export --track` is quiet on success — so a `SealKeyUnavailable` prints on `cd` (realizing B1 through the hook, which the plan claimed but the code muted). `formatError` now renders that error with the searched key paths + remediation, not just the bare tag.
- **bash array `PROMPT_COMMAND`** (bash ≥5.1): appends to the array instead of string-concatenating (which dropped all but element 0).

## Added
- **`shell-hook --no-audit`** — omit the per-`cd` `audit` spawn (slow machines).
- **`init --global`** scaffolds `scope = "shell"`; **`init --scope <shell|exec>`** is the explicit form. The global package's generator now defaults it correctly (project `init` stays `exec`).

## Why this matters (the zsh-vs-Ubuntu thread)
Separately confirmed: zsh's `chpwd` doesn't fire at shell startup (bash's `PROMPT_COMMAND` does), which is why the on-`cd` count showed on Ubuntu but not a fresh zsh terminal. A3's run-once call already fixes that — once you're on 0.13.x and re-eval the hook, zsh matches bash.

## Testing
- New/updated: init scope scaffolding; decouple (plain emits / `--track` withholds); hook surfaces missing-key error on `cd` (no age needed — the guard fires pre-decrypt); `--no-audit`; array-`PROMPT_COMMAND` content.
- Full `pnpm validate` green: format, lint, typecheck, **564 tests**, schema, build.

Docs: `env-export` (rewrote the scope section for explicit-vs-ambient), `shell-hook` (`--no-audit`), CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)