### PR TITLE
feat(cli): envpkt doctor + platform-aware age-not-found guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`envpkt doctor`** — one-shot environment check: is the `age` CLI installed, is a config
+  resolvable for this directory, and do its sealed secrets decrypt with an available key? Reuses
+  the boot resolution path, so a missing key reports the same searched-paths guidance as a failed
+  boot. Exits non-zero if a check fails.
+
+### Changed
+
+- **Clearer guidance when the `age` CLI is missing.** `AgeNotFound` errors (from `keygen`, `seal`,
+  decryption) now print a platform-aware install command (`brew install age` / `apt install age` /
+  `scoop install age`) plus the install link, instead of a bare "not found" message.
+
 ## [0.13.1] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -364,6 +364,19 @@ envpkt audit -c path/to/envpkt.toml # Specify config path
 
 Exit codes: `0` = healthy, `1` = degraded, `2` = critical.
 
+### `envpkt doctor`
+
+One-shot environment check: is the `age` CLI installed, is a config resolvable here, and do its sealed secrets decrypt with an available key?
+
+```bash
+envpkt doctor
+# ✓ age      v1.2.0
+# ✓ config   /path/to/envpkt.toml
+# ✓ secrets  5 resolved, 0 skipped
+```
+
+If `age` is missing it prints the platform-specific install command; if a sealed packet has no key, it lists the paths it searched. Exits non-zero when a check fails.
+
 ### `envpkt resolve`
 
 Resolve catalog references and output a flat, self-contained config.

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,0 +1,75 @@
+import { bootSafe } from "../../core/boot.js"
+import { resolveConfigPath } from "../../core/config.js"
+import type { BootError } from "../../core/types.js"
+import { ageInstallHint, ageVersion } from "../../fnox/identity.js"
+import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "../output.js"
+
+type DoctorOptions = {
+  readonly config?: string
+}
+
+const ok = (label: string, detail: string): void => console.log(`  ${GREEN}✓${RESET} ${label}  ${DIM}${detail}${RESET}`)
+const warn = (label: string, detail: string): void => console.log(`  ${YELLOW}—${RESET} ${label}  ${detail}`)
+const bad = (label: string, detail: string): void => console.log(`  ${RED}✗${RESET} ${label}  ${detail}`)
+
+/** Print the resolution/key check, returning whether it passed. */
+const reportResolution = (configPath: string): boolean =>
+  bootSafe({ configPath, inject: false, warnOnly: true }).fold(
+    (err: BootError) => {
+      if (err._tag === "SealKeyUnavailable") {
+        bad("key   ", `${err.sealedKeys.length} sealed secret(s) but no decryption key`)
+        err.searched.forEach((line) => console.log(`${DIM}        ${line}${RESET}`))
+      } else {
+        bad("config", `${err._tag}`)
+      }
+      return false
+    },
+    (boot) => {
+      const resolved = Object.keys(boot.secrets).length
+      ok("secrets", `${resolved} resolved, ${boot.skipped.length} skipped`)
+      const auditColor = boot.audit.status === "healthy" ? GREEN : YELLOW
+      console.log(`  ${auditColor}•${RESET} audit   ${DIM}${boot.audit.status}${RESET}`)
+      return true
+    },
+  )
+
+/**
+ * One-shot environment check: is age installed, is a config resolvable, and do its sealed
+ * secrets decrypt with an available key? Read-only; exits non-zero if any check fails.
+ */
+export const runDoctor = (options: DoctorOptions): void => {
+  console.log(`${BOLD}envpkt doctor${RESET}\n`)
+
+  const ageOk = ageVersion().fold(
+    () => {
+      bad("age   ", "not found on PATH")
+      console.log(`${DIM}        ${ageInstallHint().split("\n").join("\n        ")}${RESET}`)
+      return false
+    },
+    (version) => {
+      ok("age   ", version)
+      return true
+    },
+  )
+
+  const resolveOk = resolveConfigPath(options.config).fold(
+    () => {
+      warn("config", "no envpkt.toml found for this directory")
+      return true // not an error — envpkt works without a config present
+    },
+    ({ path }) => {
+      ok("config", path)
+      return reportResolution(path)
+    },
+  )
+
+  console.log("")
+  if (ageOk && resolveOk) {
+    console.log(`${GREEN}✓ no issues${RESET}`)
+  } else {
+    console.log(
+      `${RED}✗ ${[!ageOk, !resolveOk].filter(Boolean).length} issue(s) found${RESET} ${CYAN}(see above)${RESET}`,
+    )
+    process.exit(1)
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { Command } from "commander"
 
 import { runAudit } from "./commands/audit.js"
 import { runConfigPath } from "./commands/config-path.js"
+import { runDoctor } from "./commands/doctor.js"
 import { registerEnvCommands } from "./commands/env.js"
 import { runExec } from "./commands/exec.js"
 import { runFleet } from "./commands/fleet.js"
@@ -181,6 +182,14 @@ program
   .description("Upgrade envpkt to the latest version (npm install -g envpkt@latest)")
   .action(() => {
     runUpgrade()
+  })
+
+program
+  .command("doctor")
+  .description("Check that age is installed and that the resolved config's sealed secrets can be decrypted")
+  .option("-c, --config <path>", "Path to envpkt.toml")
+  .action((options) => {
+    runDoctor(options)
   })
 
 program

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,6 +1,7 @@
 import type { CheckResult, ScanResult } from "../core/env.js"
 import type { ConfidenceLevel } from "../core/patterns.js"
 import type { AuditResult, FleetHealth, HealthStatus, SecretHealth } from "../core/types.js"
+import { ageInstallHint } from "../fnox/identity.js"
 
 const RESET = "\x1b[0m"
 const BOLD = "\x1b[1m"
@@ -175,7 +176,7 @@ export const formatError = (error: { _tag: string; message?: string; path?: stri
     case "ReadError":
       return `${RED}Error:${RESET} Could not read file: ${error.message}`
     case "AgeNotFound":
-      return `${RED}Error:${RESET} age CLI not found: ${error.message}`
+      return `${RED}Error:${RESET} age is required for this operation but was not found on PATH.\n${DIM}${ageInstallHint()}${RESET}`
     case "DecryptFailed":
       return `${RED}Error:${RESET} Decrypt failed: ${error.message}`
     case "IdentityNotFound":

--- a/src/fnox/identity.ts
+++ b/src/fnox/identity.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
 
 import type { Either } from "functype"
-import { Left, Right, Try } from "functype"
+import { Left, Option, Right, Try } from "functype"
 
 import type { IdentityError } from "../core/types.js"
 
@@ -15,6 +15,24 @@ export const ageAvailable = (): boolean =>
     () => false,
     (v) => v,
   )
+
+/** The age CLI version string (e.g. "v1.2.0"), or None if age isn't on PATH. */
+export const ageVersion = (): Option<string> =>
+  Try(() => execFileSync("age", ["--version"], { stdio: ["pipe", "pipe", "pipe"], encoding: "utf-8" }).trim()).fold(
+    () => Option.none<string>(),
+    (v) => Option(v),
+  )
+
+/** Platform-aware instructions for installing the age CLI. */
+export const ageInstallHint = (): string => {
+  const byPlatform: Record<string, string> = {
+    darwin: "brew install age",
+    linux: "apt install age   (or: apk add age · dnf install age · nix-env -iA nixpkgs.age)",
+    win32: "scoop install age   (or: winget install FiloSottile.age)",
+  }
+  const cmd = byPlatform[process.platform] ?? "see the install guide"
+  return `Install age:\n    ${cmd}\n    https://github.com/FiloSottile/age#installation`
+}
 
 /**
  * Extract the secret key from an age identity file (plain or encrypted).


### PR DESCRIPTION
Detect-and-guide for the `age` CLI dependency — the pragmatic alternative to bundling a binary or the (breaking, async) typage migration in #41.

## Why this instead of bundling / typage
For a *credentials* tool, bundling age means either a postinstall binary download (a supply-chain surface) or maintaining per-platform vendored-binary packages on age's security-release treadmill. And bundling doesn't even *remove* the dependency — only typage does, and that forces `boot()` async (breaking). So: make the dependency **obvious and one-command-easy** now; leave the actual removal (#41) as a deliberate breaking release later.

## Added
- **`envpkt doctor`** — one-shot environment check:
  ```
  ✓ age      v1.2.0
  ✓ config   /path/envpkt.toml
  ✓ secrets  5 resolved, 0 skipped
  ```
  Reuses `bootSafe`, so a missing key reports the same searched-paths guidance as a failed boot, and a missing age prints the install command. Exits non-zero on any failed check. (Read-only; composes already-tested pieces — `resolveConfigPath`, `bootSafe`/B1, the age check — so no dedicated spec.)

## Changed
- **`AgeNotFound` now renders platform-aware install guidance** (`brew install age` / `apt install age` / `scoop install age` + link) via `formatError`, so `keygen`/`seal`/decrypt failures point you straight at the fix. New `ageInstallHint()` / `ageVersion()` helpers.

## Notes
- `pnpm validate` green: format, typecheck, **564 tests**, schema, build. One **non-blocking** lint warning remains on `doctor.ts` (functype `prefer-do-notation` heuristic on the `bootSafe().fold`) — `lint` exits 0, CI publishes fine; left as-is rather than suppress/refactor for a soft heuristic.
- Docs: README CLI Reference gains an `envpkt doctor` entry; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)