### PR TITLE
feat(cli): envpkt diff — compare two configs by secret/env entries (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`envpkt diff <a> <b>`** compares two configs by their `[secret.*]`/`[env.*]` entries —
+  keys only in each side plus field-level metadata changes for shared keys. Ignores
+  `encrypted_value` ciphertext (same secret re-encrypts differently) but reports sealed-status
+  changes. `--format json` for scripting; `--exit-code` exits non-zero on any difference (CI drift
+  gate). New library API: `diffConfigs`. ([#22](https://github.com/jordanburke/envpkt/issues/22))
+
 ## [0.13.2] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -405,6 +405,25 @@ envpkt inspect --secrets --plaintext  # Show secret values in plaintext
 
 The `--secrets` flag reads values from environment variables matching each secret key. By default values are masked (`pos•••••yapp`). Add `--plaintext` to display full values.
 
+### `envpkt diff`
+
+Compare two configs — useful for spotting drift between environments (e.g. `dev.envpkt.toml` vs `prod.envpkt.toml`). Reports keys only in each side and field-level metadata changes for shared keys. Sealed ciphertext is ignored (the same secret re-encrypts differently); a sealed↔unsealed change is reported.
+
+```bash
+envpkt diff dev.envpkt.toml prod.envpkt.toml
+# - dev.envpkt.toml
+# + prod.envpkt.toml
+#
+# [secret]
+#   - OLD_KEY
+#   + NEW_KEY
+#   ~ API_KEY
+#       expires: 2026-01-01 → 2027-01-01
+
+envpkt diff a.toml b.toml --format json   # structured diff
+envpkt diff a.toml b.toml --exit-code     # exit non-zero on any difference (CI drift gate)
+```
+
 ### `envpkt exec`
 
 Run a pre-flight audit, inject secrets from fnox into the environment, then execute a command.

--- a/docs/plans/2026-06-14-cloud-verification.md
+++ b/docs/plans/2026-06-14-cloud-verification.md
@@ -21,7 +21,7 @@ verification is **continuous and fleet-wide**:
 - **Centralized audit log** of every check.
 
 It also handles, server-side and correctly, the things that made ad-hoc local probing risky:
-a verification call is itself a credential *use* (it shows in provider audit logs, consumes
+a verification call is itself a credential _use_ (it shows in provider audit logs, consumes
 rate limits, can trip anomaly detection). Centralized scheduling with backoff is the right home
 for that — not every contributor's terminal firing authenticated calls at prod providers.
 

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -1,0 +1,54 @@
+import { loadConfig } from "../../core/config.js"
+import { diffConfigs, type SectionDiff } from "../../core/diff.js"
+import type { EnvpktConfig } from "../../core/types.js"
+import { BOLD, DIM, formatError, GREEN, RED, RESET, YELLOW } from "../output.js"
+
+type DiffOptions = {
+  readonly format?: string
+  readonly exitCode?: boolean
+}
+
+const formatSection = (name: string, s: SectionDiff): ReadonlyArray<string> => {
+  if (s.onlyA.length === 0 && s.onlyB.length === 0 && s.changed.length === 0) return []
+  return [
+    `${BOLD}[${name}]${RESET}`,
+    ...s.onlyA.map((k) => `  ${RED}- ${k}${RESET}`),
+    ...s.onlyB.map((k) => `  ${GREEN}+ ${k}${RESET}`),
+    ...s.changed.flatMap((c) => [
+      `  ${YELLOW}~ ${c.key}${RESET}`,
+      ...c.changes.map((ch) => `      ${ch.field}: ${DIM}${ch.a ?? "∅"}${RESET} → ${DIM}${ch.b ?? "∅"}${RESET}`),
+    ]),
+  ]
+}
+
+const loadOrExit = (path: string, side: string): EnvpktConfig =>
+  loadConfig(path).fold(
+    (err) => {
+      console.error(`${RED}Error${RESET} (${side} = ${path}): ${formatError(err)}`)
+      process.exit(2)
+      return undefined! // unreachable
+    },
+    (config) => config,
+  )
+
+/**
+ * Compare two envpkt.toml files by their `[secret.*]` and `[env.*]` entries. Reports keys only in
+ * each side and field-level metadata changes for shared keys (ciphertext is ignored; sealed-status
+ * changes are reported). With `--exit-code`, exits non-zero when the configs differ.
+ */
+export const runDiff = (pathA: string, pathB: string, options: DiffOptions): void => {
+  const diff = diffConfigs(loadOrExit(pathA, "a"), loadOrExit(pathB, "b"))
+
+  if (options.format === "json") {
+    console.log(JSON.stringify(diff, null, 2))
+  } else if (diff.identical) {
+    console.log(`${GREEN}✓${RESET} no differences`)
+  } else {
+    const body = [...formatSection("secret", diff.secret), ...formatSection("env", diff.env)]
+    console.log(`${DIM}- ${pathA}\n+ ${pathB}${RESET}\n\n${body.join("\n")}`)
+  }
+
+  if (options.exitCode && !diff.identical) {
+    process.exit(1)
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { Command } from "commander"
 
 import { runAudit } from "./commands/audit.js"
 import { runConfigPath } from "./commands/config-path.js"
+import { runDiff } from "./commands/diff.js"
 import { runDoctor } from "./commands/doctor.js"
 import { registerEnvCommands } from "./commands/env.js"
 import { runExec } from "./commands/exec.js"
@@ -182,6 +183,17 @@ program
   .description("Upgrade envpkt to the latest version (npm install -g envpkt@latest)")
   .action(() => {
     runUpgrade()
+  })
+
+program
+  .command("diff")
+  .description("Compare two envpkt.toml configs by their secret/env entries (keys + metadata)")
+  .argument("<a>", "First config path")
+  .argument("<b>", "Second config path")
+  .option("--format <format>", "Output format: text | json", "text")
+  .option("--exit-code", "Exit non-zero when the configs differ (for CI drift gates)")
+  .action((a: string, b: string, options) => {
+    runDiff(a, b, options)
   })
 
 program

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -1,0 +1,86 @@
+/* eslint-disable functype/prefer-option, functype/prefer-fold -- ConfigDiff is a JSON-serializable DTO (round-trips through `diff --format json`); fields use `string | undefined` where undefined means "field absent on that side". Option has no place in the serialized shape. */
+import type { EnvMeta, EnvpktConfig, SecretMeta } from "./schema.js"
+
+/** A single field that differs between two entries. `undefined` means the field is absent on that side. */
+export type FieldChange = {
+  readonly field: string
+  readonly a: string | undefined
+  readonly b: string | undefined
+}
+
+/** An entry present in both configs whose metadata differs. */
+export type ChangedEntry = {
+  readonly key: string
+  readonly changes: ReadonlyArray<FieldChange>
+}
+
+/** Diff of one keyed section (`[secret.*]` or `[env.*]`). Key lists are sorted. */
+export type SectionDiff = {
+  readonly onlyA: ReadonlyArray<string>
+  readonly onlyB: ReadonlyArray<string>
+  readonly changed: ReadonlyArray<ChangedEntry>
+}
+
+export type ConfigDiff = {
+  readonly secret: SectionDiff
+  readonly env: SectionDiff
+  readonly identical: boolean
+}
+
+/** Normalize a metadata value to a comparable/displayable string (`undefined` = absent). */
+const serialize = (value: unknown): string | undefined =>
+  value === undefined ? undefined : typeof value === "string" ? value : JSON.stringify(value)
+
+type Meta = SecretMeta | EnvMeta
+
+/**
+ * Field-level diff of two entries. `encrypted_value` is excluded from value comparison — the same
+ * secret re-encrypts to different ciphertext, so diffing it is noise — but a change in *sealed
+ * status* (present ↔ absent) is reported as a synthetic `sealed` field.
+ */
+const metaDiff = (a: Meta, b: Meta): ReadonlyArray<FieldChange> => {
+  const ar = a as Record<string, unknown>
+  const br = b as Record<string, unknown>
+
+  const sealedChange: ReadonlyArray<FieldChange> =
+    !!ar["encrypted_value"] === !!br["encrypted_value"]
+      ? []
+      : [{ field: "sealed", a: ar["encrypted_value"] ? "yes" : "no", b: br["encrypted_value"] ? "yes" : "no" }]
+
+  const fieldKeys = [...Object.keys(ar), ...Object.keys(br)].filter(
+    (k, i, arr) => k !== "encrypted_value" && arr.indexOf(k) === i,
+  )
+
+  const fieldChanges = fieldKeys.flatMap((field) => {
+    const av = serialize(ar[field])
+    const bv = serialize(br[field])
+    return av === bv ? [] : [{ field, a: av, b: bv }]
+  })
+
+  return [...sealedChange, ...fieldChanges.sort((x, y) => x.field.localeCompare(y.field))]
+}
+
+const sectionDiff = (a: Readonly<Record<string, Meta>>, b: Readonly<Record<string, Meta>>): SectionDiff => {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  return {
+    onlyA: aKeys.filter((k) => !(k in b)).sort(),
+    onlyB: bKeys.filter((k) => !(k in a)).sort(),
+    changed: aKeys
+      .filter((k) => k in b)
+      .sort()
+      .flatMap((key) => {
+        const changes = metaDiff(a[key]!, b[key]!)
+        return changes.length === 0 ? [] : [{ key, changes }]
+      }),
+  }
+}
+
+const isEmpty = (s: SectionDiff): boolean => s.onlyA.length === 0 && s.onlyB.length === 0 && s.changed.length === 0
+
+/** Compare two configs by their `[secret.*]` and `[env.*]` entries (metadata, not ciphertext). */
+export const diffConfigs = (a: EnvpktConfig, b: EnvpktConfig): ConfigDiff => {
+  const secret = sectionDiff(a.secret ?? {}, b.secret ?? {})
+  const env = sectionDiff(a.env ?? {}, b.env ?? {})
+  return { secret, env, identical: isEmpty(secret) && isEmpty(env) }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,10 @@ export { resolveValues } from "./core/resolve-values.js"
 export type { DotenvEntry, FormatDotenvOptions } from "./core/dotenv.js"
 export { formatDotenv, quoteDotenvValue } from "./core/dotenv.js"
 
+// Config diff
+export type { ChangedEntry, ConfigDiff, FieldChange, SectionDiff } from "./core/diff.js"
+export { diffConfigs } from "./core/diff.js"
+
 // TOML editing
 export { appendSection, removeSection, renameSection, updateSectionFields } from "./core/toml-edit.js"
 

--- a/test/cli/diff.spec.ts
+++ b/test/cli/diff.spec.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+const __testDir = dirname(fileURLToPath(import.meta.url))
+const PROJECT_ROOT = resolve(__testDir, "../..")
+const CLI_SRC = resolve(PROJECT_ROOT, "src/cli/index.ts")
+const TSX = resolve(PROJECT_ROOT, "node_modules/.bin/tsx")
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "envpkt-diff-"))
+})
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const write = (name: string, content: string): string => {
+  const p = join(tmpDir, name)
+  writeFileSync(p, content)
+  return p
+}
+
+const run = (args: string[]): { stdout: string; status: number } => {
+  try {
+    const stdout = execFileSync(TSX, [CLI_SRC, "diff", ...args], { encoding: "utf-8" })
+    return { stdout, status: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; status?: number }
+    return { stdout: e.stdout ?? "", status: e.status ?? 1 }
+  }
+}
+
+const DEV = `version = 1\n\n[secret.API_KEY]\nservice = "stripe"\nexpires = "2026-01-01"\n\n[secret.OLD]\nservice = "x"\n`
+const PROD = `version = 1\n\n[secret.API_KEY]\nservice = "stripe"\nexpires = "2027-01-01"\n\n[secret.NEW]\nservice = "y"\n`
+
+describe("envpkt diff", () => {
+  it("reports added/removed/changed and exits 0 by default", () => {
+    const a = write("dev.toml", DEV)
+    const b = write("prod.toml", PROD)
+    const { stdout, status } = run([a, b])
+    expect(status).toBe(0)
+    expect(stdout).toContain("- OLD")
+    expect(stdout).toContain("+ NEW")
+    expect(stdout).toContain("~ API_KEY")
+    expect(stdout).toContain("expires:")
+  })
+
+  it("reports no differences for identical configs", () => {
+    const a = write("a.toml", DEV)
+    const { stdout, status } = run([a, a])
+    expect(status).toBe(0)
+    expect(stdout).toContain("no differences")
+  })
+
+  it("--exit-code exits 1 on difference, 0 when identical", () => {
+    const a = write("dev.toml", DEV)
+    const b = write("prod.toml", PROD)
+    expect(run([a, b, "--exit-code"]).status).toBe(1)
+    expect(run([a, a, "--exit-code"]).status).toBe(0)
+  })
+
+  it("--format json emits a structured diff", () => {
+    const a = write("dev.toml", DEV)
+    const b = write("prod.toml", PROD)
+    const parsed = JSON.parse(run([a, b, "--format", "json"]).stdout)
+    expect(parsed.secret.onlyA).toEqual(["OLD"])
+    expect(parsed.secret.onlyB).toEqual(["NEW"])
+    expect(parsed.identical).toBe(false)
+  })
+
+  it("exits 2 when a config file can't be loaded", () => {
+    const a = write("dev.toml", DEV)
+    expect(run([a, join(tmpDir, "nope.toml")]).status).toBe(2)
+  })
+})

--- a/test/core/diff.spec.ts
+++ b/test/core/diff.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import { diffConfigs } from "../../src/core/diff.js"
+import type { EnvpktConfig } from "../../src/core/types.js"
+
+const cfg = (partial: Partial<EnvpktConfig>): EnvpktConfig => ({ version: 1, ...partial })
+
+describe("diffConfigs", () => {
+  it("reports identical configs", () => {
+    const a = cfg({ secret: { API_KEY: { service: "stripe" } } })
+    const b = cfg({ secret: { API_KEY: { service: "stripe" } } })
+    const d = diffConfigs(a, b)
+    expect(d.identical).toBe(true)
+    expect(d.secret.onlyA).toEqual([])
+    expect(d.secret.onlyB).toEqual([])
+    expect(d.secret.changed).toEqual([])
+  })
+
+  it("reports keys only in A (removed) and only in B (added), sorted", () => {
+    const a = cfg({ secret: { OLD: { service: "x" }, KEEP: { service: "x" } } })
+    const b = cfg({ secret: { KEEP: { service: "x" }, NEW: { service: "y" }, ALSO_NEW: { service: "z" } } })
+    const d = diffConfigs(a, b)
+    expect(d.identical).toBe(false)
+    expect(d.secret.onlyA).toEqual(["OLD"])
+    expect(d.secret.onlyB).toEqual(["ALSO_NEW", "NEW"])
+  })
+
+  it("reports field-level metadata changes for shared keys", () => {
+    const a = cfg({ secret: { API_KEY: { service: "stripe", expires: "2026-01-01", capabilities: ["read"] } } })
+    const b = cfg({
+      secret: { API_KEY: { service: "stripe", expires: "2027-01-01", capabilities: ["read", "write"] } },
+    })
+    const d = diffConfigs(a, b)
+    expect(d.secret.changed).toHaveLength(1)
+    const change = d.secret.changed[0]!
+    expect(change.key).toBe("API_KEY")
+    const fields = Object.fromEntries(change.changes.map((c) => [c.field, [c.a, c.b]]))
+    expect(fields["expires"]).toEqual(["2026-01-01", "2027-01-01"])
+    expect(fields["capabilities"]).toEqual(['["read"]', '["read","write"]'])
+    expect(fields["service"]).toBeUndefined() // unchanged → not reported
+  })
+
+  it("ignores encrypted_value ciphertext but reports a sealed-status change", () => {
+    const a = cfg({ secret: { K: { service: "x", encrypted_value: "AAA...ciphertext-one" } } })
+    const b = cfg({ secret: { K: { service: "x", encrypted_value: "BBB...ciphertext-two" } } })
+    // Same sealed status, different ciphertext → NOT a change.
+    expect(diffConfigs(a, b).identical).toBe(true)
+
+    const unsealed = cfg({ secret: { K: { service: "x" } } })
+    const d = diffConfigs(unsealed, a)
+    const sealed = d.secret.changed[0]!.changes.find((c) => c.field === "sealed")
+    expect(sealed).toEqual({ field: "sealed", a: "no", b: "yes" })
+  })
+
+  it("diffs env entries too (including value)", () => {
+    const a = cfg({ env: { LOG_LEVEL: { value: "info" } } })
+    const b = cfg({ env: { LOG_LEVEL: { value: "debug" }, PORT: { value: "3000" } } })
+    const d = diffConfigs(a, b)
+    expect(d.env.onlyB).toEqual(["PORT"])
+    const valChange = d.env.changed[0]!.changes.find((c) => c.field === "value")
+    expect(valChange).toEqual({ field: "value", a: "info", b: "debug" })
+  })
+})


### PR DESCRIPTION
Closes #22.

Adds `envpkt diff <a> <b>` to compare two configs — the drift check people lose when migrating off dotenvx (no more `jq`-ing `inspect --format json`). Built as specced.

## Behavior
```
envpkt diff dev.envpkt.toml prod.envpkt.toml
# - dev.envpkt.toml
# + prod.envpkt.toml
#
# [secret]
#   - OLD_KEY          (only in a)
#   + NEW_KEY          (only in b)
#   ~ API_KEY
#       expires: 2026-01-01 → 2027-01-01
# [env]
#   ~ LOG_LEVEL
#       value: info → debug
```

- Compares `[secret.*]` + `[env.*]` entries: **only-in-a**, **only-in-b**, and **changed** (field-level metadata diff for shared keys).
- **Ignores `encrypted_value` ciphertext** — the same secret re-encrypts to different bytes, so diffing it is noise — but reports a **sealed↔unsealed** status change.
- `--format json` emits the structured `ConfigDiff`; `--exit-code` exits non-zero on any difference (CI drift gate). Default exit is `0`.
- Operates on loaded/validated configs (a `--resolved` catalog-merged mode is a clean follow-up, not v1).

## Structure
Pure `diffConfigs(a, b)` core in `src/core/diff.ts` (exported from the library); the CLI only formats. The DTO is JSON-serializable (`string | undefined` fields, undefined = absent) — file-level functype disable documents why Option isn't used in the serialized shape.

## Testing
- 5 core unit tests (added/removed/changed, ciphertext-ignored/sealed-status, env value diff) + 5 CLI tests (text, identical, `--exit-code` 0/1, json, load error → exit 2).
- Full `pnpm validate` green: format, lint, typecheck, **574 tests**, schema, build. (One pre-existing non-blocking `doctor.ts` lint warning remains from #52, unrelated.)

Docs: README CLI Reference entry + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)